### PR TITLE
Prepare driver-jms for Pulsar and Kafka JMS benchmarks

### DIFF
--- a/driver-jms/README.md
+++ b/driver-jms/README.md
@@ -2,4 +2,64 @@
 
 With this driver you can run the benchmark against any messaging system that supports JMS 1.1 or JMS 2.0 API.
 
-For instructions on running the OpenMessaging benchmarks for JMS, see the [official documentation](http://openmessaging.cloud/docs/benchmarks/jms).
+For instructions on running the OpenMessaging benchmarks for JMS, see the [official documentation](https://github.com/openmessaging/openmessaging.github.io/blob/source/docs/benchmarks/jms.md).
+
+## Modifying the Openmessaging Benchmark Tar for JMS
+
+Rather than simply dropping a JMS Client Library into `/opt/benchmark/lib` the lib directory tar file is modified.
+
+### DataStax Starlight for JMS / Pulsar Fast JMS
+
+Follow these instructions to compile the openmessaging benchmark for Fast JMS for Apache Pulsar
+
+- Build the openmessaging benchmark package as you would normally
+  ```
+  mvn clean package
+  ```
+- Run the repacking script
+  ```
+  bash driver-jms/package-pulsar.sh
+  ```
+
+You can now deploy to AWS from `driver-pulsar/deploy`.
+
+### Confluent JMS Client / Kafka JMS
+
+Follow the [Confluent instructions][1] to create a fat jar.
+
+- Create a directory
+  ```
+  cd ~
+  mkdir kafka-jms-client
+  cd kafka-jms-client
+  ```
+- Create the pom.xml
+- Change `<url>http://packages.confluent.io/maven/</url>` to `<url>https://packages.confluent.io/maven/</url>`
+- Build the fat jar
+  ```
+  mvn clean package
+  ```
+
+Follow these instructions to compile the openmessaging benchmark for Confluent JMS Client
+
+- Build the openmessaging benchmark package
+  ```
+  mvn clean package
+  ```
+- Run the repacking script passing in the location of the fat jar. EG. `~/kafka-jms-client/target/kafka-jms-client-fat-6.2.1.jar`
+  ```
+  bash driver-jms/package-kafka.sh /path/to/the/kafka-jms-client.jar
+  ```
+
+You can now deploy to AWS from `driver-kafka/deploy`.
+
+## JMS Driver Benchmarks
+
+For Pulsar JMS (and likely Kafka) you will likely want to allocate additional consumer clients.
+
+- Edit your `terraform.tfvars` file to adjust `num_instances["client"]`.
+- Run `bin/benchmark` with the `--extra` option to allocate more workers as consumers.
+
+
+
+[1]: https://docs.confluent.io/platform/current/clients/kafka-jms-client/installation.html#appendix-1

--- a/driver-jms/kafka-jms.yaml
+++ b/driver-jms/kafka-jms.yaml
@@ -30,19 +30,18 @@ use20api: false
 # So we are going to delegate the initialization to another specific Driver
 delegateForAdminOperationsClassName: io.openmessaging.benchmark.driver.kafka.KafkaBenchmarkDriver
 
-# Kafka specific configuration
 # the code that handles this configuration is the KafkaBenchmarkDriver
-replicationFactor: 1
+replicationFactor: 3
 
 topicConfig: |
-  min.insync.replicas=1
+  min.insync.replicas=2
 
 commonConfig: |
   bootstrap.servers=localhost:9092
 
 producerConfig: |
   acks=all
-  linger.ms=200
+  linger.ms=1
   batch.size=524288
 
 consumerConfig: |

--- a/driver-jms/package-kafka.sh
+++ b/driver-jms/package-kafka.sh
@@ -1,0 +1,9 @@
+# the one argument is the path to the confluent jms client fat jar on your local system
+
+cd package/target
+gunzip openmessaging-benchmark-0.0.1-SNAPSHOT-bin.tar.gz 
+mkdir -p openmessaging-benchmark-0.0.1-SNAPSHOT/lib 
+cp -p ${1} openmessaging-benchmark-0.0.1-SNAPSHOT/lib/.
+tar --append --file=openmessaging-benchmark-0.0.1-SNAPSHOT-bin.tar openmessaging-benchmark-0.0.1-SNAPSHOT/lib/kafka-jms-client-fat-6.2.1.jar
+gzip openmessaging-benchmark-0.0.1-SNAPSHOT-bin.tar
+

--- a/driver-jms/package-pulsar.sh
+++ b/driver-jms/package-pulsar.sh
@@ -1,0 +1,10 @@
+cd package/target
+tar zxvf openmessaging-benchmark-0.0.1-SNAPSHOT-bin.tar.gz
+cd openmessaging-benchmark-0.0.1-SNAPSHOT
+rm lib/org.apache.pulsar-*
+rm lib/*jackson*
+curl https://repo1.maven.org/maven2/com/datastax/oss/pulsar-jms-all/1.2.2/pulsar-jms-all-1.2.2.jar -o lib/pulsar-jms-all-1.2.2.jar
+cd ..
+rm openmessaging-benchmark-0.0.1-SNAPSHOT-bin.tar.gz
+tar zcvf openmessaging-benchmark-0.0.1-SNAPSHOT-bin.tar.gz openmessaging-benchmark-0.0.1-SNAPSHOT
+

--- a/driver-jms/src/main/java/io/openmessaging/benchmark/driver/jms/JMSBenchmarkConsumer.java
+++ b/driver-jms/src/main/java/io/openmessaging/benchmark/driver/jms/JMSBenchmarkConsumer.java
@@ -66,8 +66,6 @@ public class JMSBenchmarkConsumer implements BenchmarkConsumer {
 	// See https://jakarta.ee/specifications/platform/8/apidocs/javax/jms/session#close--
 	// and https://jakarta.ee/specifications/platform/8/apidocs/javax/jms/connection#close--
 	// It should be enough to just close the connection.
-        // consumer.close();
-        // session.close();
         connection.close();
     }
 

--- a/driver-jms/src/main/java/io/openmessaging/benchmark/driver/jms/JMSBenchmarkConsumer.java
+++ b/driver-jms/src/main/java/io/openmessaging/benchmark/driver/jms/JMSBenchmarkConsumer.java
@@ -50,8 +50,7 @@ public class JMSBenchmarkConsumer implements BenchmarkConsumer {
         consumer.setMessageListener(message -> {
             try {
                 byte[] payload = getPayload(message);
-                callback.messageReceived(payload, message.getJMSTimestamp());
-
+                callback.messageReceived(payload, message.getLongProperty("E2EStartMillis"));
                 message.acknowledge();
             } catch (Throwable e) {
                 log.warn("Failed to acknowledge message", e);
@@ -63,8 +62,12 @@ public class JMSBenchmarkConsumer implements BenchmarkConsumer {
 
     @Override
     public void close() throws Exception {
-        consumer.close();
-        session.close();
+	// This exception may be thrown: java.util.concurrent.ExecutionException: java.util.ConcurrentModificationException: KafkaConsumer is not safe for multi-threaded access
+	// See https://jakarta.ee/specifications/platform/8/apidocs/javax/jms/session#close--
+	// and https://jakarta.ee/specifications/platform/8/apidocs/javax/jms/connection#close--
+	// It should be enough to just close the connection.
+        // consumer.close();
+        // session.close();
         connection.close();
     }
 

--- a/driver-jms/src/main/java/io/openmessaging/benchmark/driver/jms/JMSBenchmarkProducer.java
+++ b/driver-jms/src/main/java/io/openmessaging/benchmark/driver/jms/JMSBenchmarkProducer.java
@@ -74,6 +74,8 @@ public class JMSBenchmarkProducer implements BenchmarkProducer {
             for (JMSConfig.AddProperty prop : properties) {
                 bytesMessage.setStringProperty(prop.name, prop.value);
             }
+	    // Add a timer property for end to end
+	    bytesMessage.setLongProperty("E2EStartMillis",System.currentTimeMillis());
             if (useAsyncSend) {
                 producer.send(bytesMessage, new CompletionListener()
                 {

--- a/driver-jms/src/main/java/io/openmessaging/benchmark/driver/jms/JMSBenchmarkProducer.java
+++ b/driver-jms/src/main/java/io/openmessaging/benchmark/driver/jms/JMSBenchmarkProducer.java
@@ -88,7 +88,7 @@ public class JMSBenchmarkProducer implements BenchmarkProducer {
                     @Override
                     public void onException(Message message, Exception exception)
                     {
-                        log.info("send completed with error", exception);
+                        log.error("send completed with error", exception);
                         res.completeExceptionally(exception);
                     }
                 });

--- a/driver-jms/src/main/java/io/openmessaging/benchmark/driver/jms/JMSBenchmarkTransactionProducer.java
+++ b/driver-jms/src/main/java/io/openmessaging/benchmark/driver/jms/JMSBenchmarkTransactionProducer.java
@@ -65,6 +65,8 @@ public class JMSBenchmarkTransactionProducer implements BenchmarkProducer {
             for (JMSConfig.AddProperty prop : properties) {
                 bytesMessage.setStringProperty(prop.name, prop.value);
             }
+	    // Add a timer property for end to end
+	    bytesMessage.setLongProperty("E2EStartMillis",System.currentTimeMillis());
             if (useAsyncSend) {
                 CompletableFuture<Void> res = new CompletableFuture<>();
                 producer.send(bytesMessage, new CompletionListener()
@@ -78,7 +80,7 @@ public class JMSBenchmarkTransactionProducer implements BenchmarkProducer {
                     @Override
                     public void onException(Message message, Exception exception)
                     {
-                        log.error("send completed with error", exception);
+                        log.info("send completed with error", exception);
                         res.completeExceptionally(exception);
                     }
                 });


### PR DESCRIPTION
Instructions and scripts for adding in JMS Clients to the OMB tarball.
Allow the JMS connection to close the consumer and session.
Track Latency via a message property
