### PR TITLE
Benchmark and worker fixes and enhancements

### DIFF
--- a/benchmark-framework/pom.xml
+++ b/benchmark-framework/pom.xml
@@ -165,6 +165,12 @@
 		</dependency>
 
 		<dependency>
+ 		  <groupId>io.netty</groupId>
+ 		  <artifactId>netty-all</artifactId>
+ 		  <version>4.1.48.Final</version>
+ 		</dependency> 
+ 
+ 		<dependency>
 			<groupId>org.apache.bookkeeper.stats</groupId>
 			<artifactId>bookkeeper-stats-api</artifactId>
 			<version>${bookkeeper.version}</version>

--- a/benchmark-framework/pom.xml
+++ b/benchmark-framework/pom.xml
@@ -164,12 +164,6 @@
 			<version>${project.version}</version>
 		</dependency>
 
-		<dependency>
- 		  <groupId>io.netty</groupId>
- 		  <artifactId>netty-all</artifactId>
- 		  <version>4.1.48.Final</version>
- 		</dependency> 
- 
  		<dependency>
 			<groupId>org.apache.bookkeeper.stats</groupId>
 			<artifactId>bookkeeper-stats-api</artifactId>

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Benchmark.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Benchmark.java
@@ -64,6 +64,9 @@ public class Benchmark {
                 "--workers-file" }, description = "Path to a YAML file containing the list of workers addresses")
         public File workersFile;
 
+        @Parameter(names = { "-x", "--extra" }, description = "Allocate extra consumer workers")
+        boolean extraConsumers;
+
         @Parameter(description = "Workloads")//, required = true)
         public List<String> workloads;
     }
@@ -126,7 +129,7 @@ public class Benchmark {
         Worker worker;
 
         if (arguments.workers != null && !arguments.workers.isEmpty()) {
-            worker = new DistributedWorkersEnsemble(arguments.workers);
+            worker = new DistributedWorkersEnsemble(arguments.workers, arguments.extraConsumers);
         } else {
             // Use local worker implementation
             worker = new LocalWorker();

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Benchmark.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Benchmark.java
@@ -64,7 +64,7 @@ public class Benchmark {
                 "--workers-file" }, description = "Path to a YAML file containing the list of workers addresses")
         public File workersFile;
 
-        @Parameter(names = { "-x", "--extra" }, description = "Allocate extra consumer workers")
+        @Parameter(names = { "-x", "--extra" }, description = "Allocate extra consumer workers when your backlog builds.")
         boolean extraConsumers;
 
         @Parameter(description = "Workloads")//, required = true)

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
@@ -159,11 +159,7 @@ public class WorkloadGenerator implements AutoCloseable {
         // In this case we just publish 1 message and then wait for consumers to receive the data
         worker.probeProducers();
 
-	// do not loop forever
-	int countdown = 20;	
-        while (countdown > 0) {
-	    countdown--;
-
+	while (true) {
             CountersStats stats = worker.getCountersStats();
 	    
             if (stats.messagesReceived < expectedMessages) {

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
@@ -76,11 +76,10 @@ public class WorkloadGenerator implements AutoCloseable {
         List<String> topics = worker.createTopics(new TopicsInfo(workload.topics, workload.partitionsPerTopic));
         log.info("Created {} topics in {} ms", topics.size(), timer.elapsedMillis());
 
-        createProducers(topics);
         createConsumers(topics);
+        createProducers(topics);
 
-	// Current versions of Kafka don't need to ensure topics are ready. Just create the producers first
-        // ensureTopicsAreReady();
+        ensureTopicsAreReady();
 
         if (workload.producerRate > 0) {
             targetPublishRate = workload.producerRate;

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/DistributedWorkersEnsemble.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/DistributedWorkersEnsemble.java
@@ -66,13 +66,17 @@ public class DistributedWorkersEnsemble implements Worker {
 
     private int numberOfUsedProducerWorkers;
 
-    public DistributedWorkersEnsemble(List<String> workers) {
+    public DistributedWorkersEnsemble(List<String> workers, boolean extraConsumerWorkers) {
         Preconditions.checkArgument(workers.size() > 1);
 
         this.workers = workers;
-        List<List<String>> partitions = Lists.partition(workers, workers.size() / 2);
-        this.producerWorkers = partitions.get(0);
-        this.consumerWorkers = partitions.get(1);
+
+	// For driver-jms extra consumers are required.
+	// If there is an odd number of workers then allocate the extra to consumption.
+	int numberOfProducerWorkers = extraConsumerWorkers ? (workers.size() + 2) / 3 : workers.size() / 2;
+	List<List<String>> partitions = Lists.partition(Lists.reverse(workers), workers.size() - numberOfProducerWorkers);
+	this.producerWorkers = partitions.get(1); 
+	this.consumerWorkers = partitions.get(0);
 
         log.info("Workers list - producers: {}", producerWorkers);
         log.info("Workers list - consumers: {}", consumerWorkers);

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/LocalWorker.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/LocalWorker.java
@@ -185,16 +185,16 @@ public class LocalWorker implements Worker, ConsumerCallback {
 
         rateLimiter.setRate(producerWorkAssignment.publishRate);
 
-        Map<Integer, List<BenchmarkProducer>> processorAssignemnt = new TreeMap<>();
+        Map<Integer, List<BenchmarkProducer>> processorAssignment = new TreeMap<>();
 
         int processorIdx = 0;
         for (BenchmarkProducer p : producers) {
-            processorAssignemnt.computeIfAbsent(processorIdx, x -> new ArrayList<BenchmarkProducer>()).add(p);
+            processorAssignment.computeIfAbsent(processorIdx, x -> new ArrayList<BenchmarkProducer>()).add(p);
 
             processorIdx = (processorIdx + 1) % processors;
         }
 
-        processorAssignemnt.values().forEach(producers -> submitProducersToExecutor(producers,
+        processorAssignment.values().forEach(producers -> submitProducersToExecutor(producers,
                 KeyDistributor.build(producerWorkAssignment.keyDistributorType), producerWorkAssignment.payloadData));
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,6 @@
 		<module>benchmark-framework</module>
 		<module>driver-api</module>
 
-		<module>driver-pravega</module>
 		<module>driver-pulsar</module>
 		<module>driver-kafka</module>
 		<module>driver-rabbitmq</module>
@@ -43,7 +42,6 @@
 		<module>driver-nats-streaming</module>
 		<module>driver-nsq</module>
 		<module>driver-jms</module>
-		<module>driver-redis</module>
 		<module>package</module>
 		<module>docker</module>
 	</modules>
@@ -65,18 +63,6 @@
 
 	<build>
 		<plugins>
-			<plugin>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-					<encoding>UTF-8</encoding>
-					<showDeprecation>true</showDeprecation>
-					<showWarnings>true</showWarnings>
-					<optimize>true</optimize>
-				</configuration>
-			</plugin>
 			<plugin>
 				<groupId>com.mycila</groupId>
 				<artifactId>license-maven-plugin</artifactId>
@@ -128,6 +114,12 @@
 			<artifactId>jackson-dataformat-yaml</artifactId>
 			<version>2.9.3</version>
 		</dependency>
+		<dependency>
+		  <groupId>io.netty</groupId>
+		  <artifactId>netty-all</artifactId>
+		  <version>4.1.48.Final</version>
+		</dependency> 
+
 	</dependencies>
 	
 	<dependencyManagement>
@@ -140,4 +132,57 @@
 		</dependencies>
 	</dependencyManagement>
 
+	<profiles>
+		<profile>
+			<id>modern-java-compile</id>
+			<activation>
+				<jdk>[9,)</jdk>
+			</activation>
+			<build>
+				<pluginManagement>
+					<plugins>
+						<plugin>
+							<groupId>org.apache.maven.plugins</groupId>
+							<artifactId>maven-compiler-plugin</artifactId>
+							<version>3.8.1</version>
+							<configuration>
+								<source>8</source>
+								<target>8</target>
+								<release>8</release>
+								<encoding>UTF-8</encoding>
+								<showDeprecation>true</showDeprecation>
+								<showWarnings>true</showWarnings>
+								<optimize>true</optimize>
+							</configuration>
+						</plugin>
+					</plugins>
+				</pluginManagement>
+			</build>
+		</profile>
+		<profile>
+			<id>jdk-8-compile</id>
+			<activation>
+				<jdk>[,8]</jdk>
+			</activation>
+			<build>
+				<pluginManagement>
+					<plugins>
+						<plugin>
+							<groupId>org.apache.maven.plugins</groupId>
+							<artifactId>maven-compiler-plugin</artifactId>
+							<version>3.8.1</version>
+							<configuration>
+								<source>8</source>
+								<target>8</target>
+								<encoding>UTF-8</encoding>
+								<showDeprecation>true</showDeprecation>
+								<showWarnings>true</showWarnings>
+								<optimize>true</optimize>
+							</configuration>
+						</plugin>
+					</plugins>
+				</pluginManagement>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
 		<module>benchmark-framework</module>
 		<module>driver-api</module>
 
+		<module>driver-pravega</module>
 		<module>driver-pulsar</module>
 		<module>driver-kafka</module>
 		<module>driver-rabbitmq</module>
@@ -42,6 +43,7 @@
 		<module>driver-nats-streaming</module>
 		<module>driver-nsq</module>
 		<module>driver-jms</module>
+		<module>driver-redis</module>
 		<module>package</module>
 		<module>docker</module>
 	</modules>


### PR DESCRIPTION
netty-all dependency needed update for openjdk11 support due to reflection errors in coordinating with workers
In testing Kafka JMS  (Confluent JMS Client) ensureTopicsAreReady could infinite loop. The benchmark started better creating the producers before the consumers.
In testing Pulsar Fast JMS (Starlight for JMS) we needed more consumers to get the messages per second throughput we wanted.