### PR TITLE
Fix NPE in RabbitMQ driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ core/*.json
 *.json
 *.retry
 *.pem
+*.hcl
 **/.terraform
 **/terraform.tfstate
 **/terraform.tfstate.backup

--- a/driver-pulsar/src/main/java/io/openmessaging/benchmark/driver/pulsar/PulsarBenchmarkDriver.java
+++ b/driver-pulsar/src/main/java/io/openmessaging/benchmark/driver/pulsar/PulsarBenchmarkDriver.java
@@ -170,7 +170,7 @@ public class PulsarBenchmarkDriver implements BenchmarkDriver {
     @Override
     public CompletableFuture<BenchmarkProducer> createProducer(String topic) {
         return producerBuilder.topic(topic).createAsync()
-                        .thenApply(pulsarProducer -> new PulsarBenchmarkProducer(pulsarProducer));
+                        .thenApply(PulsarBenchmarkProducer::new);
     }
 
     @Override

--- a/driver-rabbitmq/src/main/java/io/openmessaging/benchmark/driver/rabbitmq/RabbitMqBenchmarkDriver.java
+++ b/driver-rabbitmq/src/main/java/io/openmessaging/benchmark/driver/rabbitmq/RabbitMqBenchmarkDriver.java
@@ -65,7 +65,9 @@ public class RabbitMqBenchmarkDriver implements BenchmarkDriver {
 
     @Override
     public void close() throws Exception {
-        connection.close();
+        if (connection != null) {
+            connection.close();
+        }
     }
 
     @Override


### PR DESCRIPTION
If the connection failed to be established in `initialize`, and `close` is called (for instance through the `/stop-all` endpoint), an NPE occurs because `connection` is null.