### PR TITLE
Use i3en.6xlarge for Pulsar and Kafka

### DIFF
--- a/driver-bookkeeper/deploy/terraform.tfvars
+++ b/driver-bookkeeper/deploy/terraform.tfvars
@@ -3,9 +3,9 @@ region          = "us-west-2"
 ami             = "ami-9fa343e7" // RHEL-7.4
 
 instance_types = {
-  "bookkeeper"  = "i3en.2xlarge"
+  "bookkeeper"  = "i3en.6xlarge"
   "zookeeper"   = "t2.small"
-  "client"      = "c5.2xlarge"
+  "client"      = "m5n.8xlarge"
   "prometheus"  = "t2.small"
 }
 

--- a/driver-kafka/deploy/ssd-deployment/deploy.yaml
+++ b/driver-kafka/deploy/ssd-deployment/deploy.yaml
@@ -204,12 +204,12 @@
       lineinfile:
          dest: /opt/benchmark/bin/benchmark-worker
          regexp: '^JVM_MEM='
-         line: 'JVM_MEM="-Xms12G -Xmx12G -XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB -XX:+PerfDisableSharedMem -XX:+AlwaysPreTouch -XX:-UseBiasedLocking"'
+         line: 'JVM_MEM="-Xms100G -Xmx100G -XX:+UnlockExperimentalVMOptions -XX:+UseZGC -XX:+ParallelRefProcEnabled -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=12 -XX:ConcGCThreads=12 -XX:+DisableExplicitGC -XX:-ResizePLAB"'
     - name: Configure memory
       lineinfile:
          dest: /opt/benchmark/bin/benchmark
          regexp: '^JVM_MEM='
-         line: 'JVM_MEM="-Xmx1G"'
+         line: 'JVM_MEM="-Xmx4G"'
     - template:
         src: "templates/workers.yaml"
         dest: "/opt/benchmark/workers.yaml"

--- a/driver-kafka/deploy/ssd-deployment/templates/kafka.service
+++ b/driver-kafka/deploy/ssd-deployment/templates/kafka.service
@@ -4,8 +4,8 @@ After=network.target
 
 [Service]
 ExecStart=/opt/kafka/bin/kafka-server-start.sh config/server.properties
-Environment='KAFKA_HEAP_OPTS=-Xms6g -Xmx6g -XX:MetaspaceSize=96m'
-Environment='KAFKA_JVM_PERFORMANCE_OPTS=-server -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:G1HeapRegionSize=16M -XX:MinMetaspaceFreeRatio=50 -XX:MaxMetaspaceFreeRatio=80 -Djava.awt.headless=true"
+Environment='KAFKA_HEAP_OPTS=-Xms16g -Xmx16g -XX:MetaspaceSize=96m'
+Environment='KAFKA_JVM_PERFORMANCE_OPTS=-server -XX:+UnlockExperimentalVMOptions -XX:+UseZGC -XX:+ParallelRefProcEnabled -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=12 -XX:ConcGCThreads=12 -XX:+DisableExplicitGC -XX:-ResizePLAB -XX:MinMetaspaceFreeRatio=50 -XX:MaxMetaspaceFreeRatio=80 -Djava.awt.headless=true"
 WorkingDirectory=/opt/kafka
 RestartSec=1s
 Restart=on-failure

--- a/driver-kafka/deploy/ssd-deployment/terraform.tfvars
+++ b/driver-kafka/deploy/ssd-deployment/terraform.tfvars
@@ -4,9 +4,9 @@ az              = "us-west-2a"
 ami             = "ami-9fa343e7" // RHEL-7.4
 
 instance_types = {
-  "kafka"     = "i3en.2xlarge"
+  "kafka"     = "i3en.6xlarge"
   "zookeeper" = "t2.small"
-  "client"    = "c5.4xlarge"
+  "client"    = "m5n.8xlarge"
 }
 
 num_instances = {

--- a/driver-pravega/deploy/terraform.tfvars
+++ b/driver-pravega/deploy/terraform.tfvars
@@ -4,9 +4,9 @@ ami             = "ami-9fa343e7" // RHEL-7.4 us-west-2
 
 instance_types = {
   "controller"   = "m5.large"
-  "bookkeeper"   = "i3en.2xlarge"
+  "bookkeeper"   = "i3en.6xlarge"
   "zookeeper"    = "t2.small"
-  "client"       = "c5.2xlarge"
+  "client"       = "m5n.8xlarge"
   "metrics"      = "t2.large"
 }
 

--- a/driver-pulsar/deploy/ssd/deploy_with_stats.yaml
+++ b/driver-pulsar/deploy/ssd/deploy_with_stats.yaml
@@ -132,8 +132,8 @@
         extra_opts: ["--strip-components=1"]
     - set_fact:
         private_ip: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}"
-        max_heap_memory: "8g"
-        max_direct_memory: "16g"
+        max_heap_memory: "16g"
+        max_direct_memory: "48g"
     - template:
         src: "templates/pulsar_env.sh"
         dest: "/opt/pulsar/conf/pulsar_env.sh"
@@ -321,7 +321,7 @@
       lineinfile:
          dest: /opt/benchmark/bin/benchmark-worker
          regexp: '^JVM_MEM='
-         line: 'JVM_MEM="-Xms6G -Xmx12G -XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=8 -XX:ConcGCThreads=8 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB -XX:+PerfDisableSharedMem -XX:+AlwaysPreTouch -XX:-UseBiasedLocking"'
+         line: 'JVM_MEM="-Xms100G -Xmx100G -XX:+UnlockExperimentalVMOptions -XX:+UseZGC -XX:+ParallelRefProcEnabled -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=12 -XX:ConcGCThreads=12 -XX:+DisableExplicitGC -XX:-ResizePLAB"'
     - name: Configure memory
       lineinfile:
          dest: /opt/benchmark/bin/benchmark

--- a/driver-pulsar/deploy/ssd/templates/bookkeeper-skip-journal.conf
+++ b/driver-pulsar/deploy/ssd/templates/bookkeeper-skip-journal.conf
@@ -29,9 +29,6 @@ ledgerDirectories=/mnt/journal/0,/mnt/journal/1,/mnt/storage/0,/mnt/storage/1
 journalSyncData=false
 journalWriteData=false
 
-# Set PageCache flush interval (millisecond) when journalSyncData disabled
-journalPageCacheFlushIntervalMSec=1000
-
 ## Regular Bookie settings
 
 # Port that bookie server listen on

--- a/driver-pulsar/deploy/ssd/templates/bookkeeper.conf
+++ b/driver-pulsar/deploy/ssd/templates/bookkeeper.conf
@@ -29,9 +29,6 @@ ledgerDirectories=/mnt/storage/0,/mnt/storage/1
 journalSyncData=true
 journalWriteData=true
 
-# Set PageCache flush interval (millisecond) when journalSyncData disabled
-journalPageCacheFlushIntervalMSec=1000
-
 ## Regular Bookie settings
 
 # Port that bookie server listen on

--- a/driver-pulsar/deploy/ssd/terraform.tfvars
+++ b/driver-pulsar/deploy/ssd/terraform.tfvars
@@ -3,9 +3,9 @@ region          = "us-west-2"
 ami             = "ami-9fa343e7" // RHEL-7.4
 
 instance_types = {
-  "pulsar"      = "i3en.2xlarge"
+  "pulsar"      = "i3en.6xlarge"
   "zookeeper"   = "t2.small"
-  "client"      = "c5n.2xlarge"
+  "client"      = "m5n.8xlarge"
   "prometheus"  = "t2.large"
 }
 

--- a/driver-rabbitmq/deploy/terraform.tfvars
+++ b/driver-rabbitmq/deploy/terraform.tfvars
@@ -3,8 +3,8 @@ region          = "us-west-2"
 ami             = "ami-9fa343e7" // RHEL-7.4
 
 instance_types = {
-  "rabbitmq"  = "i3en.2xlarge"
-  "client"    = "c4.8xlarge"
+  "rabbitmq"  = "i3en.6xlarge"
+  "client"    = "m5n.8xlarge"
 }
 
 num_instances = {

--- a/workloads/1-topic-100-partitions-1kb-4p-4c-1000k.yaml
+++ b/workloads/1-topic-100-partitions-1kb-4p-4c-1000k.yaml
@@ -17,8 +17,22 @@
 # under the License.
 #
 
-- name: Restart all benchmark worker for Pulsar
-  hosts: client
-  tasks:
-    - name: Restart Pulsar benckmark workers
-      shell: sudo service benchmark-worker restart
+name: 1000k rate 4 producers and 4 consumers on 1 topic / 100 partition
+
+topics: 1
+partitionsPerTopic: 100
+
+messageSize: 1024
+useRandomizedPayloads: true
+randomBytesRatio: 0.5
+randomizedPayloadPoolSize: 1000
+
+subscriptionsPerTopic: 1
+consumerPerSubscription: 4
+producersPerTopic: 4
+
+# Discover max-sustainable rate
+producerRate: 1000000
+
+consumerBacklogSizeGB: 0
+testDurationMinutes: 5

--- a/workloads/1-topic-100-partitions-1kb-4p-4c-200k.yaml
+++ b/workloads/1-topic-100-partitions-1kb-4p-4c-200k.yaml
@@ -17,36 +17,22 @@
 # under the License.
 #
 
-name: Pulsar
-driverClass: io.openmessaging.benchmark.driver.pulsar.PulsarBenchmarkDriver
+name: 200k rate 4 producers and 4 consumers on 1 topic / 100 partition
 
-# Pulsar client-specific configuration
-client:
-  serviceUrl: pulsar://localhost:6650
-  httpUrl: http://localhost:8080
-  ioThreads: 16
-  connectionsPerBroker: 8
-  clusterName: local
-  namespacePrefix: benchmark/ns
-  topicType: persistent
-  persistence:
-    ensembleSize: 3
-    writeQuorum: 3
-    ackQuorum: 2
-    deduplicationEnabled: false
-  tlsAllowInsecureConnection: false
-  tlsEnableHostnameVerification: false
-  tlsTrustCertsFilePath:
-  authentication:
-    plugin:
-    data:
+topics: 1
+partitionsPerTopic: 100
 
-# Producer configuration
-producer:
-  batchingEnabled: true
-  batchingMaxPublishDelayMs: 1
-  blockIfQueueFull: true
-  pendingQueueSize: 0
+messageSize: 1024
+useRandomizedPayloads: true
+randomBytesRatio: 0.5
+randomizedPayloadPoolSize: 1000
 
-consumer:
-  receiverQueueSize: 10000
+subscriptionsPerTopic: 1
+consumerPerSubscription: 4
+producersPerTopic: 4
+
+# Discover max-sustainable rate
+producerRate: 200000
+
+consumerBacklogSizeGB: 0
+testDurationMinutes: 5

--- a/workloads/1-topic-100-partitions-1kb-4p-4c-500k-backlog.yaml
+++ b/workloads/1-topic-100-partitions-1kb-4p-4c-500k-backlog.yaml
@@ -17,36 +17,22 @@
 # under the License.
 #
 
-name: Pulsar
-driverClass: io.openmessaging.benchmark.driver.pulsar.PulsarBenchmarkDriver
+name: Backlog for 500k rate 4 producers and 4 consumers on 1 topic / 100 partition
 
-# Pulsar client-specific configuration
-client:
-  serviceUrl: pulsar://localhost:6650
-  httpUrl: http://localhost:8080
-  ioThreads: 16
-  connectionsPerBroker: 8
-  clusterName: local
-  namespacePrefix: benchmark/ns
-  topicType: persistent
-  persistence:
-    ensembleSize: 3
-    writeQuorum: 3
-    ackQuorum: 2
-    deduplicationEnabled: false
-  tlsAllowInsecureConnection: false
-  tlsEnableHostnameVerification: false
-  tlsTrustCertsFilePath:
-  authentication:
-    plugin:
-    data:
+topics: 1
+partitionsPerTopic: 100
 
-# Producer configuration
-producer:
-  batchingEnabled: true
-  batchingMaxPublishDelayMs: 1
-  blockIfQueueFull: true
-  pendingQueueSize: 0
+messageSize: 1024
+useRandomizedPayloads: true
+randomBytesRatio: 0.5
+randomizedPayloadPoolSize: 1000
 
-consumer:
-  receiverQueueSize: 10000
+subscriptionsPerTopic: 1
+consumerPerSubscription: 4
+producersPerTopic: 4
+
+# Discover max-sustainable rate
+producerRate: 500000
+
+consumerBacklogSizeGB: 512
+testDurationMinutes: 5

--- a/workloads/1-topic-100-partitions-1kb-4p-4c-500k.yaml
+++ b/workloads/1-topic-100-partitions-1kb-4p-4c-500k.yaml
@@ -17,36 +17,22 @@
 # under the License.
 #
 
-name: Pulsar
-driverClass: io.openmessaging.benchmark.driver.pulsar.PulsarBenchmarkDriver
+name: 500k rate 4 producers and 4 consumers on 1 topic / 100 partition
 
-# Pulsar client-specific configuration
-client:
-  serviceUrl: pulsar://localhost:6650
-  httpUrl: http://localhost:8080
-  ioThreads: 16
-  connectionsPerBroker: 8
-  clusterName: local
-  namespacePrefix: benchmark/ns
-  topicType: persistent
-  persistence:
-    ensembleSize: 3
-    writeQuorum: 3
-    ackQuorum: 2
-    deduplicationEnabled: false
-  tlsAllowInsecureConnection: false
-  tlsEnableHostnameVerification: false
-  tlsTrustCertsFilePath:
-  authentication:
-    plugin:
-    data:
+topics: 1
+partitionsPerTopic: 100
 
-# Producer configuration
-producer:
-  batchingEnabled: true
-  batchingMaxPublishDelayMs: 1
-  blockIfQueueFull: true
-  pendingQueueSize: 0
+messageSize: 1024
+useRandomizedPayloads: true
+randomBytesRatio: 0.5
+randomizedPayloadPoolSize: 1000
 
-consumer:
-  receiverQueueSize: 10000
+subscriptionsPerTopic: 1
+consumerPerSubscription: 4
+producersPerTopic: 4
+
+# Discover max-sustainable rate
+producerRate: 500000
+
+consumerBacklogSizeGB: 0
+testDurationMinutes: 5

--- a/workloads/1-topic-10000-partitions-1kb-4p-4c-1000k.yaml
+++ b/workloads/1-topic-10000-partitions-1kb-4p-4c-1000k.yaml
@@ -17,36 +17,22 @@
 # under the License.
 #
 
-name: Pulsar
-driverClass: io.openmessaging.benchmark.driver.pulsar.PulsarBenchmarkDriver
+name: 1000k rate 4 producers and 4 consumers on 1 topic / 10000 partition
 
-# Pulsar client-specific configuration
-client:
-  serviceUrl: pulsar://localhost:6650
-  httpUrl: http://localhost:8080
-  ioThreads: 16
-  connectionsPerBroker: 8
-  clusterName: local
-  namespacePrefix: benchmark/ns
-  topicType: persistent
-  persistence:
-    ensembleSize: 3
-    writeQuorum: 3
-    ackQuorum: 2
-    deduplicationEnabled: false
-  tlsAllowInsecureConnection: false
-  tlsEnableHostnameVerification: false
-  tlsTrustCertsFilePath:
-  authentication:
-    plugin:
-    data:
+topics: 1
+partitionsPerTopic: 10000
 
-# Producer configuration
-producer:
-  batchingEnabled: true
-  batchingMaxPublishDelayMs: 1
-  blockIfQueueFull: true
-  pendingQueueSize: 0
+messageSize: 1024
+useRandomizedPayloads: true
+randomBytesRatio: 0.5
+randomizedPayloadPoolSize: 1000
 
-consumer:
-  receiverQueueSize: 10000
+subscriptionsPerTopic: 1
+consumerPerSubscription: 4
+producersPerTopic: 4
+
+# Discover max-sustainable rate
+producerRate: 1000000
+
+consumerBacklogSizeGB: 0
+testDurationMinutes: 5

--- a/workloads/1-topic-10000-partitions-1kb-4p-4c-200k.yaml
+++ b/workloads/1-topic-10000-partitions-1kb-4p-4c-200k.yaml
@@ -17,36 +17,22 @@
 # under the License.
 #
 
-name: Pulsar
-driverClass: io.openmessaging.benchmark.driver.pulsar.PulsarBenchmarkDriver
+name: 200k rate 4 producers and 4 consumers on 1 topic / 10000 partition
 
-# Pulsar client-specific configuration
-client:
-  serviceUrl: pulsar://localhost:6650
-  httpUrl: http://localhost:8080
-  ioThreads: 16
-  connectionsPerBroker: 8
-  clusterName: local
-  namespacePrefix: benchmark/ns
-  topicType: persistent
-  persistence:
-    ensembleSize: 3
-    writeQuorum: 3
-    ackQuorum: 2
-    deduplicationEnabled: false
-  tlsAllowInsecureConnection: false
-  tlsEnableHostnameVerification: false
-  tlsTrustCertsFilePath:
-  authentication:
-    plugin:
-    data:
+topics: 1
+partitionsPerTopic: 10000
 
-# Producer configuration
-producer:
-  batchingEnabled: true
-  batchingMaxPublishDelayMs: 1
-  blockIfQueueFull: true
-  pendingQueueSize: 0
+messageSize: 1024
+useRandomizedPayloads: true
+randomBytesRatio: 0.5
+randomizedPayloadPoolSize: 1000
 
-consumer:
-  receiverQueueSize: 10000
+subscriptionsPerTopic: 1
+consumerPerSubscription: 4
+producersPerTopic: 4
+
+# Discover max-sustainable rate
+producerRate: 200000
+
+consumerBacklogSizeGB: 0
+testDurationMinutes: 5

--- a/workloads/1-topic-10000-partitions-1kb-4p-4c-500k.yaml
+++ b/workloads/1-topic-10000-partitions-1kb-4p-4c-500k.yaml
@@ -17,36 +17,22 @@
 # under the License.
 #
 
-name: Pulsar
-driverClass: io.openmessaging.benchmark.driver.pulsar.PulsarBenchmarkDriver
+name: 500k rate 4 producers and 4 consumers on 1 topic / 10000 partition
 
-# Pulsar client-specific configuration
-client:
-  serviceUrl: pulsar://localhost:6650
-  httpUrl: http://localhost:8080
-  ioThreads: 16
-  connectionsPerBroker: 8
-  clusterName: local
-  namespacePrefix: benchmark/ns
-  topicType: persistent
-  persistence:
-    ensembleSize: 3
-    writeQuorum: 3
-    ackQuorum: 2
-    deduplicationEnabled: false
-  tlsAllowInsecureConnection: false
-  tlsEnableHostnameVerification: false
-  tlsTrustCertsFilePath:
-  authentication:
-    plugin:
-    data:
+topics: 1
+partitionsPerTopic: 10000
 
-# Producer configuration
-producer:
-  batchingEnabled: true
-  batchingMaxPublishDelayMs: 1
-  blockIfQueueFull: true
-  pendingQueueSize: 0
+messageSize: 1024
+useRandomizedPayloads: true
+randomBytesRatio: 0.5
+randomizedPayloadPoolSize: 1000
 
-consumer:
-  receiverQueueSize: 10000
+subscriptionsPerTopic: 1
+consumerPerSubscription: 4
+producersPerTopic: 4
+
+# Discover max-sustainable rate
+producerRate: 500000
+
+consumerBacklogSizeGB: 0
+testDurationMinutes: 5


### PR DESCRIPTION
- Use i3en.6xlarge for Pulsar and Kafka broker
- Use m5n.8xlarge for Client to avoid the client side bottleneck
- Use ZGC for test client
- Add more workloads