### PR TITLE
support `--output` parameter

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Benchmark.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Benchmark.java
@@ -69,6 +69,9 @@ public class Benchmark {
 
         @Parameter(description = "Workloads")//, required = true)
         public List<String> workloads;
+
+        @Parameter(names = { "-o", "--output" }, description = "Output", required = false)
+        public String output;
     }
 
     public static void main(String[] args) throws Exception {
@@ -153,8 +156,10 @@ public class Benchmark {
 
                     TestResult result = generator.run();
 
-                    String fileName = String.format("%s-%s-%s.json", workloadName, driverConfiguration.name,
-                            dateFormat.format(new Date()));
+                    boolean useOutput = (arguments.output != null) && (arguments.output.length() > 0);
+
+                    String fileName = useOutput? arguments.output: String.format("%s-%s-%s.json", workloadName,
+                    driverConfiguration.name, dateFormat.format(new Date()));
 
                     log.info("Writing test result into {}", fileName);
                     writer.writeValue(new File(fileName), result);


### PR DESCRIPTION
It is convenient to customize the name and path of the output file, and it is convenient to encapsulate the script for testing