### PR TITLE
[Pravega Driver] Unable to build benchmark for Pravega Client 0.11.0

### DIFF
--- a/driver-pravega/pom.xml
+++ b/driver-pravega/pom.xml
@@ -30,9 +30,9 @@
     <artifactId>driver-pravega</artifactId>
 
     <properties>
-        <!--Specify pravegaVersion in properties or use default: 0.10.0-->
-        <!--Provide Pravega version for build: mvn clean install  "-DpravegaVersion=0.9.0-2766.2515791-SNAPSHOT" -DskipTests=true -Dlicense.skip=true-->
-        <pravegaVersion>0.9.0</pravegaVersion>
+        <!--Specify pravegaVersion in properties or use default: 0.11.0-->
+        <!--Provide Pravega version for build: mvn clean install  "-DpravegaVersion=0.11.0-dded0f1f0-SNAPSHOT" -DskipTests=true -Dlicense.skip=true-->
+        <pravegaVersion>0.11.0</pravegaVersion>
     </properties>
 
     <repositories>
@@ -68,6 +68,7 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-all</artifactId>
+            <!-- NOTE: Please, use 1.36.0 for Pravega Client 0.10.* builds -->
             <version>1.36.2</version>
         </dependency>
 

--- a/driver-pravega/pom.xml
+++ b/driver-pravega/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <!--Specify pravegaVersion in properties or use default: 0.10.0-->
         <!--Provide Pravega version for build: mvn clean install  "-DpravegaVersion=0.9.0-2766.2515791-SNAPSHOT" -DskipTests=true -Dlicense.skip=true-->
-        <pravegaVersion>0.10.1</pravegaVersion>
+        <pravegaVersion>0.9.0</pravegaVersion>
     </properties>
 
     <repositories>
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-all</artifactId>
-            <version>1.36.0</version>
+            <version>1.36.2</version>
         </dependency>
 
         <dependency>

--- a/driver-pravega/pom.xml
+++ b/driver-pravega/pom.xml
@@ -73,6 +73,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative-boringssl-static</artifactId>
+            <version>2.0.39.Final</version>
+        </dependency>
+
+        <dependency>
             <groupId>io.perfmark</groupId>
             <artifactId>perfmark-api</artifactId>
             <version>0.23.0</version>


### PR DESCRIPTION
Hello,
This PR resolves https://github.com/openmessaging/benchmark/issues/227.
As stated within mentioned GitHub issue, I would suggest to merge the changes once Pravega 0.11.0 (or any other version containing updated gRPC dependency) is released. Until the release, this PR could be used to run OpenMessaging benchmark with current master branch of [Pravega](http://github.com/pravega/pravega).