### PR TITLE
Support for multiple RabbitMQ clients

### DIFF
--- a/driver-pulsar/deploy/ssd/templates/benchmark-worker.service
+++ b/driver-pulsar/deploy/ssd/templates/benchmark-worker.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Pulsar Broker
+Description=Benchmark worker
 After=network.target
 
 [Service]

--- a/driver-rabbitmq/deploy/deploy.yaml
+++ b/driver-rabbitmq/deploy/deploy.yaml
@@ -31,6 +31,32 @@
         - { line: "{{ hostvars[groups['rabbitmq'][2]].private_ip }} rabbitslave2" }
 
 
+- name: Format and mount disks for RabbitMQ hosts
+  hosts: rabbitmq
+  connection: ssh
+  become: true
+  tasks:
+    - name: Format disks
+      filesystem:
+        fstype: xfs
+        dev: '{{ item }}'
+      with_items:
+        - '/dev/nvme1n1'
+    - name: Mount disks
+      mount:
+        path: "{{ item.path }}"
+        src: "{{ item.src }}"
+        fstype: xfs
+        opts: defaults,noatime,nodiscard
+        state: mounted
+      with_items:
+        - { path: "/mnt/data", src: "/dev/nvme1n1" }
+    - name: Set permissions
+      file:
+        path: "/mnt/data"
+        state: touch
+        mode: "0777"
+
 - name: Install RabbitMQ Cluster
   hosts: rabbitmq
   connection: ssh
@@ -69,12 +95,11 @@
       name: "rabbitslave2"
     when: rabbitslave2 is defined
 
-  # - name: stop rabbitmq
-  #   shell: rabbitmqctl stop_app
-  # - name: kill rabbitmq
-  #   shell: rabbitmqctl stop ; ps aux | grep rabbitmq | grep -v grep | awk '{print $2}'| xargs kill -9
-  # - name: reset rabbitmq
-  #   shell: rabbitmqctl reset
+  - name: Create rabbitmq-env.conf file
+    copy:
+      dest: "/etc/rabbitmq/rabbitmq-env.conf"
+      content: |
+        MNESIA_BASE=/mnt/data
 
   - systemd:
       state: started
@@ -121,18 +146,6 @@
   - name: Create high availability policy
     shell: rabbitmqctl set_policy ha-all "^" '{"ha-mode":"exactly","ha-params":2,"ha-sync-mode":"automatic"}'
     when: rabbitmq_master is defined
-  # - name: add queue taxCodeInvoiceQueue
-  #   rabbitmq_queue: name=cmcc_zzs_taxCodeInvoiceQueue
-  #   when: rabbitmq_master is defined
-  # - name: add queue cmcc_zzs_generatorInvoiceQueue
-  #   rabbitmq_queue: name=cmcc_zzs_generatorInvoiceQueue
-  #   when: rabbitmq_master is defined
-  # - name: add queue cmcc_zzs_pushInvoiceQueue
-  #   rabbitmq_queue: name=cmcc_zzs_pushInvoiceQueue
-  #   when: rabbitmq_master is defined
-  # - name: add queue cmcc_zzs_sentToPlatformServerQueue
-  #   rabbitmq_queue: cmcc_zzs_sentToPlatformServerQueue
-  #   when: rabbitmq_master is defined
   - name: Show queue list
     shell: rabbitmqctl list_queues
     register: result_queue

--- a/driver-rabbitmq/deploy/deploy.yaml
+++ b/driver-rabbitmq/deploy/deploy.yaml
@@ -17,20 +17,6 @@
 # under the License.
 #
 
-- name: Add entries to /etc/hosts
-  hosts: all
-  connection: ssh
-  tasks:
-    - lineinfile:
-        dest: /etc/hosts
-        line: "{{ item.line }}"
-        state: present
-      with_items:
-        - { line: "{{ hostvars[groups['rabbitmq'][0]].private_ip }} rabbitmaster" }
-        - { line: "{{ hostvars[groups['rabbitmq'][1]].private_ip }} rabbitslave1" }
-        - { line: "{{ hostvars[groups['rabbitmq'][2]].private_ip }} rabbitslave2" }
-
-
 - name: Format and mount disks for RabbitMQ hosts
   hosts: rabbitmq
   connection: ssh
@@ -80,43 +66,23 @@
       name: https://github.com/rabbitmq/rabbitmq-server/releases/download/v{{ rabbitMqVersion }}/rabbitmq-server-{{ rabbitMqVersion }}-1.el7.noarch.rpm
       state: present
 
-  - name: Change master hostname to rabbitmaster
-    hostname:
-      name: "rabbitmaster"
-    when: rabbitmq_master is defined
-
-  - name: Change slave1 hostname to rabbitslave1
-    hostname:
-      name: "rabbitslave1"
-    when: rabbitslave1 is defined
-
-  - name: Change slave2 hostname to rabbitslave2
-    hostname:
-      name: "rabbitslave2"
-    when: rabbitslave2 is defined
-
   - name: Create rabbitmq-env.conf file
-    copy:
+    template:
+      src: "templates/rabbitmq-env.conf"
       dest: "/etc/rabbitmq/rabbitmq-env.conf"
-      content: |
-        MNESIA_BASE=/mnt/data
 
   - systemd:
       state: started
       daemon_reload: yes
       name: "rabbitmq-server"
+
   - name: Install web management
     shell: rabbitmq-plugins enable rabbitmq_management
   - systemd:
       state: restarted
       daemon_reload: yes
       name: "rabbitmq-server"
-  - name: create admin/admin profile
-    shell:  rabbitmqctl add_user admin  admin
-  - name: set admin tag
-    shell: rabbitmqctl set_user_tags admin administrator
-  - name: set admin permission
-    shell: rabbitmqctl set_permissions -p "/" admin ".*" ".*" ".*"
+
   - name: Clear servers' Erlang cookie
     file:
       path: /var/lib/rabbitmq/.erlang.cookie
@@ -127,29 +93,46 @@
       state: restarted
       daemon_reload: yes
       name: "rabbitmq-server"
+
   - name: RabbitMQ status
     shell: rabbitmqctl cluster_status
     register: result
   - debug:
       msg: '{{ result.stdout }}'
+
   - name: Rabbit cluster stop slaves
     shell: rabbitmqctl stop_app
-    when: rabbitmq_slave is defined
+    when: inventory_hostname != hostvars[groups['rabbitmq'][0]].inventory_hostname
+
   - name: Rabbit cluster slaves join master
-    shell: rabbitmqctl join_cluster rabbit@rabbitmaster
-    when: rabbitmq_slave is defined
+    shell: rabbitmqctl join_cluster rabbit@{{ hostvars[groups['rabbitmq'][0]].private_ip }}
+    when: inventory_hostname != hostvars[groups['rabbitmq'][0]].inventory_hostname
+
   - name: Start RabbitMQ cluster slaves
     shell: rabbitmqctl start_app
-    when: rabbitmq_slave is defined
+    when: inventory_hostname != hostvars[groups['rabbitmq'][0]].inventory_hostname
+
   - name: Show RabbitMQ cluster status
     shell: rabbitmqctl cluster_status
+    register: result
+  - debug:
+      msg: '{{ result.stdout }}'
+
+  - name: create admin/admin profile
+    shell:  rabbitmqctl add_user admin  admin
+    when: inventory_hostname == hostvars[groups['rabbitmq'][0]].inventory_hostname
+
+  - name: set admin tag
+    shell: rabbitmqctl set_user_tags admin administrator
+    when: inventory_hostname == hostvars[groups['rabbitmq'][0]].inventory_hostname
+
+  - name: set admin permission
+    shell: rabbitmqctl set_permissions -p "/" admin ".*" ".*" ".*"
+    when: inventory_hostname == hostvars[groups['rabbitmq'][0]].inventory_hostname
+
   - name: Create high availability policy
     shell: rabbitmqctl set_policy ha-all "^" '{"ha-mode":"exactly","ha-params":2,"ha-sync-mode":"automatic"}'
-    when: rabbitmq_master is defined
-  - name: Show queue list
-    shell: rabbitmqctl list_queues
-    register: result_queue
-  - debug: msg='{{result_queue.stdout}}'
+    when: inventory_hostname == hostvars[groups['rabbitmq'][0]].inventory_hostname
 
 - name: Chrony setup
   hosts: client
@@ -194,7 +177,7 @@
       lineinfile:
         dest: /opt/benchmark/driver-rabbitmq/rabbitmq.yaml
         regexp: '^brokerAddress\: '
-        line: 'brokerAddress: rabbitmaster'
+        line: "brokerAddress: {{ hostvars[groups['rabbitmq'][0]].private_ip }}"
     - name: Configure benchmark-worker memory
       lineinfile:
         dest: /opt/benchmark/bin/benchmark-worker

--- a/driver-rabbitmq/deploy/deploy.yaml
+++ b/driver-rabbitmq/deploy/deploy.yaml
@@ -42,8 +42,6 @@
     yum: pkg={{ item }} state=latest
     with_items:
       - wget
-      - java-11-openjdk
-      - java-11-openjdk-devel
       - sysstat
       - vim
       - socat
@@ -88,7 +86,7 @@
       state: restarted
       daemon_reload: yes
       name: "rabbitmq-server"
-  - name: create admin/admin  profile
+  - name: create admin/admin profile
     shell:  rabbitmqctl add_user admin  admin
   - name: set admin tag
     shell: rabbitmqctl set_user_tags admin administrator
@@ -139,8 +137,21 @@
     shell: rabbitmqctl list_queues
     register: result_queue
   - debug: msg='{{result_queue.stdout}}'
-  
-  
+
+- name: Chrony setup
+  hosts: client
+  connection: ssh
+  become: true
+  tasks:
+    - name: Set up chronyd
+      template:
+        src: "templates/chrony.conf"
+        dest: "/etc/chrony.conf"
+    - systemd:
+        state: restarted
+        daemon_reload: yes
+        name: "chronyd"
+
 - name: Rabbitmq benchmarking client setup
   hosts: client
   connection: ssh
@@ -161,17 +172,34 @@
     - shell: >
         tuned-adm profile latency-performance &&
         mv /opt/openmessaging-benchmark-0.0.1-SNAPSHOT /opt/benchmark
+
+    - template:
+        src: "templates/workers.yaml"
+        dest: "/opt/benchmark/workers.yaml"
+
     - name: Configure service URL
       lineinfile:
         dest: /opt/benchmark/driver-rabbitmq/rabbitmq.yaml
         regexp: '^brokerAddress\: '
         line: 'brokerAddress: rabbitmaster'
-    - name: Configure benchmark JVM settings
+    - name: Configure benchmark-worker memory
       lineinfile:
-         dest: /opt/benchmark/bin/benchmark
-         regexp: '^JVM_MEM='
-         line: 'JVM_MEM="-Xms24G -Xmx24G -XX:+UseG1GC -XX:MaxGCPauseMillis=10 -XX:+ParallelRefProcEnabled -XX:+UnlockExperimentalVMOptions -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=32 -XX:ConcGCThreads=32 -XX:G1NewSizePercent=50 -XX:+DisableExplicitGC -XX:-ResizePLAB -XX:+PerfDisableSharedMem -XX:+AlwaysPreTouch -XX:-UseBiasedLocking"'
-
+        dest: /opt/benchmark/bin/benchmark-worker
+        regexp: '^JVM_MEM='
+        line: 'JVM_MEM="-Xms100G -Xmx100G -XX:+UnlockExperimentalVMOptions -XX:+UseZGC -XX:+ParallelRefProcEnabled -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=12 -XX:ConcGCThreads=12 -XX:+DisableExplicitGC -XX:-ResizePLAB"'
+    - name: Configure benchmark memory
+      lineinfile:
+        dest: /opt/benchmark/bin/benchmark
+        regexp: '^JVM_MEM='
+        line: 'JVM_MEM="-Xmx4G"'
+    - name: Install benchmark-worker systemd service
+      template:
+        src: "templates/benchmark-worker.service"
+        dest: "/etc/systemd/system/benchmark-worker.service"
+    - systemd:
+        state: restarted
+        daemon_reload: yes
+        name: "benchmark-worker"
 
 - name: List host addresses
   hosts: localhost

--- a/driver-rabbitmq/deploy/templates/benchmark-worker.service
+++ b/driver-rabbitmq/deploy/templates/benchmark-worker.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Pulsar Broker
+Description=Benchmark worker
 After=network.target
 
 [Service]

--- a/driver-rabbitmq/deploy/templates/chrony.conf
+++ b/driver-rabbitmq/deploy/templates/chrony.conf
@@ -1,0 +1,54 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Use public servers from the pool.ntp.org project.
+# Please consider joining the pool (http://www.pool.ntp.org/join.html).
+server 169.254.169.123 prefer iburst
+
+# Record the rate at which the system clock gains/losses time.
+driftfile /var/lib/chrony/drift
+
+# Allow the system clock to be stepped in the first three updates
+# if its offset is larger than 1 second.
+makestep 1.0 3
+
+# Enable kernel synchronization of the real-time clock (RTC).
+rtcsync
+
+# Enable hardware timestamping on all interfaces that support it.
+#hwtimestamp *
+
+# Increase the minimum number of selectable sources required to adjust
+# the system clock.
+#minsources 2
+
+# Allow NTP client access from local network.
+#allow 192.168.0.0/16
+
+# Serve time even if not synchronized to a time source.
+#local stratum 10
+
+# Specify file containing keys for NTP authentication.
+#keyfile /etc/chrony.keys
+
+# Specify directory for log files.
+logdir /var/log/chrony
+
+# Select which information is logged.
+#log measurements statistics tracking

--- a/driver-rabbitmq/deploy/templates/rabbitmq-env.conf
+++ b/driver-rabbitmq/deploy/templates/rabbitmq-env.conf
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+MNESIA_BASE=/mnt/data
+USE_LONGNAME=true
+NODENAME=rabbit@{{ ansible_eth0.ipv4.address }}

--- a/driver-rabbitmq/deploy/terraform.tfvars
+++ b/driver-rabbitmq/deploy/terraform.tfvars
@@ -9,5 +9,5 @@ instance_types = {
 
 num_instances = {
   "rabbitmq"    = 3
-  "client"      = 1
+  "client"      = 4
 }

--- a/driver-rabbitmq/src/main/java/io/openmessaging/benchmark/driver/rabbitmq/RabbitMqBenchmarkDriver.java
+++ b/driver-rabbitmq/src/main/java/io/openmessaging/benchmark/driver/rabbitmq/RabbitMqBenchmarkDriver.java
@@ -65,7 +65,7 @@ public class RabbitMqBenchmarkDriver implements BenchmarkDriver {
 
     @Override
     public void close() throws Exception {
-        if (connection != null) {
+        if (connection != null && connection.isOpen()) {
             connection.close();
         }
     }
@@ -92,7 +92,7 @@ public class RabbitMqBenchmarkDriver implements BenchmarkDriver {
         Channel channel = null;
         try {
             channel = connection.createChannel();
-            channel.exchangeDeclare(topic, BuiltinExchangeType.FANOUT);
+            channel.exchangeDeclare(topic, BuiltinExchangeType.FANOUT, true);
             channel.confirmSelect();
         } catch (IOException e) {
             e.printStackTrace();
@@ -111,7 +111,7 @@ public class RabbitMqBenchmarkDriver implements BenchmarkDriver {
                 Channel channel = null;
                 try {
                     channel = connection.createChannel();
-                    channel.exchangeDeclare(topic, BuiltinExchangeType.FANOUT);
+                    channel.exchangeDeclare(topic, BuiltinExchangeType.FANOUT, true);
                 } catch (IOException e) {
                     e.printStackTrace();
                 }


### PR DESCRIPTION
* Add benchmark-worker service
* Mount and use the same SSD as in other benchmarks
* Remove useless java installation on RabbitMQ nodes
* Setup chrony on clients