### PR TITLE
Update Kafka version to 3.0.0 and applies confluent configurations

### DIFF
--- a/driver-kafka/deploy/hdd-deployment/templates/server.properties
+++ b/driver-kafka/deploy/hdd-deployment/templates/server.properties
@@ -26,14 +26,10 @@ log.dirs=/mnt/data-1,/mnt/data-2
 
 zookeeper.connect={{ zookeeperServers }}
 
-# EXPERIMENT WITH SOME SETTINGS
-# num.network.threads=16
+num.replica.fetchers=8
 
-# # The send buffer (SO_SNDBUF) used by the socket server
-# socket.send.buffer.bytes=1048576
+message.max.bytes=10485760
 
-# # The receive buffer (SO_RCVBUF) used by the socket server
-# socket.receive.buffer.bytes=1048576
+replica.fetch.max.bytes=10485760
 
-# # The maximum size of a request that the socket server will accept (protection against OOM)
-# socket.request.max.bytes=104857600
+num.network.threads=8

--- a/driver-kafka/deploy/ssd-deployment/deploy.yaml
+++ b/driver-kafka/deploy/ssd-deployment/deploy.yaml
@@ -85,7 +85,7 @@
     - set_fact:
         zookeeperServers: "{{ groups['zookeeper'] | map('extract', hostvars, ['ansible_default_ipv4', 'address']) | map('regex_replace', '^(.*)$', '\\1:2181') | join(',') }}"
         boostrapServers: "{{ groups['kafka'] | map('extract', hostvars, ['private_ip']) | map('regex_replace', '^(.*)$', '\\1:9092') | join(',') }}"
-        kafkaVersion: "2.8.1"
+        kafkaVersion: "3.0.0"
     - debug:
         msg: "zookeeper servers: {{ zookeeperServers }}\nboostrap servers: {{ boostrapServers }}"
     - name: Download Kafka package

--- a/driver-kafka/deploy/ssd-deployment/templates/server.properties
+++ b/driver-kafka/deploy/ssd-deployment/templates/server.properties
@@ -26,14 +26,10 @@ log.dirs=/mnt/data-1,/mnt/data-2
 
 zookeeper.connect={{ zookeeperServers }}
 
-# EXPERIMENT WITH SOME SETTINGS
-# num.network.threads=16
+num.replica.fetchers=8
 
-# # The send buffer (SO_SNDBUF) used by the socket server
-# socket.send.buffer.bytes=1048576
+message.max.bytes=10485760
 
-# # The receive buffer (SO_RCVBUF) used by the socket server
-# socket.receive.buffer.bytes=1048576
+replica.fetch.max.bytes=10485760
 
-# # The maximum size of a request that the socket server will accept (protection against OOM)
-# socket.request.max.bytes=104857600
+num.network.threads=8


### PR DESCRIPTION
- Update Kafka version to the latest 3.0.0
- Apply the [confluent configurations](https://github.com/confluentinc/openmessaging-benchmark/blob/master/driver-kafka/deploy/templates/server.properties#L29-L35)