### PR TITLE
Fix missing dash

### DIFF
--- a/deployment/kubernetes/helm/benchmark/templates/benchmark.yaml
+++ b/deployment/kubernetes/helm/benchmark/templates/benchmark.yaml
@@ -40,7 +40,7 @@ spec:
         - name: WORKERS
           value: '{{ template "workers" .Values }}'
         - name: HEAP_OPTS
-          value: 'Xms4G -Xmx4G'
+          value: '-Xms4G -Xmx4G'
       command: ["sh", "-c"]
       args:
         - >


### PR DESCRIPTION
On https://github.com/openmessaging/benchmark/pull/220 , I've added the ability to override memory `Xmx` and `Xms` but missed a dash on the default values.
Sorry for that 😅 