### PR TITLE
Create a benchmark driver for KoP (https://github.com/streamnative/kop)

### DIFF
--- a/benchmark-framework/pom.xml
+++ b/benchmark-framework/pom.xml
@@ -112,6 +112,12 @@
 
 		<dependency>
 			<groupId>${project.groupId}</groupId>
+			<artifactId>driver-kop</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>driver-pravega</artifactId>
 			<version>${project.version}</version>
 		</dependency>

--- a/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/KafkaBenchmarkConsumer.java
+++ b/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/KafkaBenchmarkConsumer.java
@@ -48,14 +48,24 @@ public class KafkaBenchmarkConsumer implements BenchmarkConsumer {
     private final Future<?> consumerTask;
     private volatile boolean closing = false;
     private boolean autoCommit;
-    public KafkaBenchmarkConsumer(KafkaConsumer<String, byte[]> consumer, Properties consumerConfig, ConsumerCallback callback) {
+
+    public KafkaBenchmarkConsumer(KafkaConsumer<String, byte[]> consumer,
+                                  Properties consumerConfig,
+                                  ConsumerCallback callback) {
+        this(consumer, consumerConfig, callback, 100L);
+    }
+
+    public KafkaBenchmarkConsumer(KafkaConsumer<String, byte[]> consumer,
+                                  Properties consumerConfig,
+                                  ConsumerCallback callback,
+                                  long pollTimeoutMs) {
         this.consumer = consumer;
         this.executor = Executors.newSingleThreadExecutor();
         this.autoCommit= Boolean.valueOf((String)consumerConfig.getOrDefault(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG,"false"));
         this.consumerTask = this.executor.submit(() -> {
             while (!closing) {
                 try {
-                    ConsumerRecords<String, byte[]> records = consumer.poll(Duration.ofMillis(100));
+                    ConsumerRecords<String, byte[]> records = consumer.poll(Duration.ofMillis(pollTimeoutMs));
 
                     Map<TopicPartition, OffsetAndMetadata> offsetMap = new HashMap<>();
                     for (ConsumerRecord<String, byte[]> record : records) {

--- a/driver-kop/kafka_to_kafka.yaml
+++ b/driver-kop/kafka_to_kafka.yaml
@@ -1,0 +1,44 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Kafka producer and Pulsar consumer
+driverClass: io.openmessaging.benchmark.driver.kop.KopBenchmarkDriver
+
+producerType: kafka
+consumerType: kafka
+
+# Pulsar configs
+pulsarConfig:
+  serviceUrl: pulsar://localhost:6650
+  # producer configs
+  batchingEnabled: true
+  batchingMaxPublishDelayMs: 1
+  batchingMaxBytes: 1048576
+  blockIfQueueFull: true
+  pendingQueueSize: 1000
+  maxPendingMessagesAcrossPartitions: 50000
+  # consumer configs
+  maxTotalReceiverQueueSizeAcrossPartitions: 50000
+  receiverQueueSize: 1000
+
+# Kafka configs
+kafkaConfig: |
+  bootstrap.servers=localhost:9092
+  linger.ms=1
+  batch.size=1048576

--- a/driver-kop/kafka_to_pulsar.yaml
+++ b/driver-kop/kafka_to_pulsar.yaml
@@ -1,0 +1,36 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Kafka producer and Pulsar consumer
+driverClass: io.openmessaging.benchmark.driver.kop.KopBenchmarkDriver
+
+producerType: kafka
+consumerType: pulsar
+
+# Pulsar configs
+pulsarConfig:
+  serviceUrl: pulsar://localhost:6650
+  batchingMaxPublishDelayMs: 1
+  batchingMaxBytes: 1048576
+
+# Kafka configs
+kafkaConfig: |
+  bootstrap.servers=localhost:9092
+  linger.ms=1
+  batch.size=1048576

--- a/driver-kop/pom.xml
+++ b/driver-kop/pom.xml
@@ -1,0 +1,66 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.openmessaging.benchmark</groupId>
+    <artifactId>messaging-benchmark</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <relativePath>..</relativePath>
+  </parent>
+
+  <artifactId>driver-kop</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>driver-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>driver-kafka</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>driver-pulsar</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.streamnative.pulsar.handlers</groupId>
+      <artifactId>kafka-payload-processor</artifactId>
+      <version>2.9.1.5</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <version>7.4.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/driver-kop/pulsar_to_kafka.yaml
+++ b/driver-kop/pulsar_to_kafka.yaml
@@ -1,0 +1,36 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Kafka producer and Pulsar consumer
+driverClass: io.openmessaging.benchmark.driver.kop.KopBenchmarkDriver
+
+producerType: pulsar
+consumerType: kafka
+
+# Pulsar configs
+pulsarConfig:
+  serviceUrl: pulsar://localhost:6650
+  batchingMaxPublishDelayMs: 1
+  batchingMaxBytes: 1048576
+
+# Kafka configs
+kafkaConfig: |
+  bootstrap.servers=localhost:9092
+  linger.ms=1
+  batch.size=1048576

--- a/driver-kop/src/main/java/io/openmessaging/benchmark/driver/kop/KopBenchmarkDriver.java
+++ b/driver-kop/src/main/java/io/openmessaging/benchmark/driver/kop/KopBenchmarkDriver.java
@@ -1,0 +1,221 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.openmessaging.benchmark.driver.kop;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.openmessaging.benchmark.driver.BenchmarkConsumer;
+import io.openmessaging.benchmark.driver.BenchmarkDriver;
+import io.openmessaging.benchmark.driver.BenchmarkProducer;
+import io.openmessaging.benchmark.driver.ConsumerCallback;
+import io.openmessaging.benchmark.driver.kafka.KafkaBenchmarkConsumer;
+import io.openmessaging.benchmark.driver.kafka.KafkaBenchmarkProducer;
+import io.openmessaging.benchmark.driver.kop.config.ClientType;
+import io.openmessaging.benchmark.driver.kop.config.Config;
+import io.openmessaging.benchmark.driver.kop.config.PulsarConfig;
+import io.openmessaging.benchmark.driver.pulsar.PulsarBenchmarkConsumer;
+import io.openmessaging.benchmark.driver.pulsar.PulsarBenchmarkProducer;
+import io.streamnative.pulsar.handlers.kop.KafkaPayloadProcessor;
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.apache.bookkeeper.stats.StatsLogger;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.ConsumerBuilder;
+import org.apache.pulsar.client.api.ProducerBuilder;
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Schema;
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.apache.pulsar.common.util.FutureUtil;
+
+public class KopBenchmarkDriver implements BenchmarkDriver {
+
+    private static final ObjectMapper mapper = new ObjectMapper(new YAMLFactory())
+            .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+
+    private final List<BenchmarkProducer> producers = new CopyOnWriteArrayList<>();
+    private final List<BenchmarkConsumer> consumers = new CopyOnWriteArrayList<>();
+
+    private Config config;
+    private AdminClient admin;
+    private Properties producerProperties;
+    private Properties consumerProperties;
+    private PulsarClient client = null;
+    private ProducerBuilder<byte[]> producerBuilder = null;
+    private ConsumerBuilder<ByteBuffer> consumerBuilder = null;
+
+    public static Config loadConfig(File file) throws IOException {
+        return mapper.readValue(file, Config.class);
+    }
+
+    @Override
+    public void initialize(File configurationFile, StatsLogger statsLogger) throws IOException {
+        config = loadConfig(configurationFile);
+        final Properties commonProperties = config.getKafkaProperties();
+        admin = AdminClient.create(commonProperties);
+
+        producerProperties = new Properties();
+        commonProperties.forEach(producerProperties::put);
+        producerProperties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        producerProperties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
+
+        consumerProperties = new Properties();
+        commonProperties.forEach(consumerProperties::put);
+        consumerProperties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        consumerProperties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
+
+        final PulsarConfig pulsarConfig = config.pulsarConfig;
+        if (config.producerType.equals(ClientType.PULSAR)) {
+            producerBuilder = getPulsarClient(pulsarConfig.serviceUrl).newProducer()
+                    .enableBatching(pulsarConfig.batchingEnabled)
+                    .blockIfQueueFull(pulsarConfig.blockIfQueueFull)
+                    .batchingMaxPublishDelay(pulsarConfig.batchingMaxPublishDelayMs, TimeUnit.MILLISECONDS)
+                    .batchingMaxBytes(pulsarConfig.batchingMaxBytes)
+                    .maxPendingMessages(pulsarConfig.pendingQueueSize)
+                    .maxPendingMessagesAcrossPartitions(pulsarConfig.maxPendingMessagesAcrossPartitions);
+        }
+        if (config.consumerType.equals(ClientType.PULSAR)) {
+            consumerBuilder = getPulsarClient(pulsarConfig.serviceUrl).newConsumer(Schema.BYTEBUFFER)
+                    .subscriptionType(SubscriptionType.Failover)
+                    .receiverQueueSize(pulsarConfig.receiverQueueSize)
+                    .maxTotalReceiverQueueSizeAcrossPartitions(pulsarConfig.maxTotalReceiverQueueSizeAcrossPartitions);
+        }
+    }
+
+    @Override
+    public String getTopicNamePrefix() {
+        return "test-topic";
+    }
+
+    @Override
+    public CompletableFuture<Void> createTopic(String topic, int partitions) {
+        // replicationFactor is meaningless in KoP
+        final NewTopic newTopic = new NewTopic(topic, partitions, (short) 1L);
+        final CompletableFuture<Void> future = new CompletableFuture<>();
+        admin.createTopics(Collections.singletonList(newTopic)).all().whenComplete((result, throwable) -> {
+            if (throwable == null) {
+                future.complete(result);
+            } else {
+                future.completeExceptionally(throwable);
+            }
+        });
+        return future;
+    }
+
+    @Override
+    public CompletableFuture<BenchmarkProducer> createProducer(String topic) {
+        if (config.producerType.equals(ClientType.KAFKA)) {
+            final BenchmarkProducer producer =
+                    new KafkaBenchmarkProducer(new KafkaProducer<>(producerProperties), topic);
+            producers.add(producer);
+            return CompletableFuture.completedFuture(producer);
+        } else if (config.consumerType.equals(ClientType.PULSAR)) {
+            return producerBuilder.clone().topic(topic).createAsync().thenApply(PulsarBenchmarkProducer::new);
+        } else {
+            throw new IllegalArgumentException("producerType " + config.producerType + " is invalid");
+        }
+    }
+
+    @Override
+    public CompletableFuture<BenchmarkConsumer> createConsumer(
+            String topic, String subscriptionName, ConsumerCallback consumerCallback) {
+        if (config.consumerType.equals(ClientType.KAFKA)) {
+            final Properties properties = new Properties();
+            consumerProperties.forEach(properties::put);
+            properties.put(ConsumerConfig.GROUP_ID_CONFIG, subscriptionName);
+            properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+            final KafkaConsumer<String, byte[]> kafkaConsumer = new KafkaConsumer<>(properties);
+            kafkaConsumer.subscribe(Collections.singleton(topic));
+            final BenchmarkConsumer consumer = new KafkaBenchmarkConsumer(
+                    kafkaConsumer, properties, consumerCallback, config.pollTimeoutMs);
+            consumers.add(consumer);
+            return CompletableFuture.completedFuture(consumer);
+        } else if (config.consumerType.equals(ClientType.PULSAR)) {
+            final List<CompletableFuture<Consumer<ByteBuffer>>> futures = new ArrayList<>();
+            return client.getPartitionsForTopic(topic)
+                    .thenCompose(partitions -> {
+                        partitions.forEach(p -> futures.add(
+                                createInternalPulsarConsumer(p, subscriptionName, consumerCallback)));
+                        return FutureUtil.waitForAll(futures);
+                    }).thenApply(__ -> new PulsarBenchmarkConsumer(futures.stream().map(CompletableFuture::join)
+                            .collect(Collectors.toList())));
+        } else {
+            throw new IllegalArgumentException("consumerType " + config.consumerType + " is invalid");
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        for (BenchmarkProducer producer : producers) {
+            producer.close();
+        }
+        for (BenchmarkConsumer consumer : consumers) {
+            consumer.close();
+        }
+        admin.close();
+        if (client != null) {
+            client.close();
+        }
+    }
+
+    private PulsarClient getPulsarClient(String serviceUrl) throws PulsarClientException {
+        if (client == null) {
+            client = PulsarClient.builder().serviceUrl(serviceUrl).build();
+        }
+        return client;
+    }
+
+    private CompletableFuture<Consumer<ByteBuffer>> createInternalPulsarConsumer(
+            String topic, String subscriptionName, ConsumerCallback callback) {
+        return consumerBuilder.clone()
+                .topic(topic)
+                .subscriptionName(subscriptionName)
+                .messagePayloadProcessor(new KafkaPayloadProcessor()) // support consuming Kafka format messages
+                .poolMessages(true)
+                .messageListener((c, msg) -> {
+                    try {
+                        callback.messageReceived(msg.getValue(), msg.getPublishTime());
+                        c.acknowledgeAsync(msg);
+                    } finally {
+                        msg.release();
+                    }
+                })
+                .subscribeAsync();
+    }
+}

--- a/driver-kop/src/main/java/io/openmessaging/benchmark/driver/kop/config/ClientType.java
+++ b/driver-kop/src/main/java/io/openmessaging/benchmark/driver/kop/config/ClientType.java
@@ -1,0 +1,26 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.openmessaging.benchmark.driver.kop.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum ClientType {
+    @JsonProperty("kafka") KAFKA,
+    @JsonProperty("pulsar") PULSAR
+}

--- a/driver-kop/src/main/java/io/openmessaging/benchmark/driver/kop/config/Config.java
+++ b/driver-kop/src/main/java/io/openmessaging/benchmark/driver/kop/config/Config.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.openmessaging.benchmark.driver.kop.config;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Properties;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.kafka.clients.producer.ProducerConfig;
+
+public class Config {
+
+    public ClientType producerType;
+    public ClientType consumerType;
+    public long pollTimeoutMs = 100;
+    public PulsarConfig pulsarConfig;
+    public String kafkaConfig;
+
+    public Properties getKafkaProperties() {
+        if (StringUtils.isEmpty(kafkaConfig)) {
+            throw new IllegalArgumentException(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG + " is not set");
+        }
+        final Properties props = new Properties();
+        try {
+            props.load(new StringReader(kafkaConfig));
+        } catch (IOException e) {
+            throw new IllegalArgumentException(e);
+        }
+        if (props.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG) == null) {
+            throw new IllegalArgumentException(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG + " is not set");
+        }
+        return props;
+    }
+}

--- a/driver-kop/src/main/java/io/openmessaging/benchmark/driver/kop/config/PulsarConfig.java
+++ b/driver-kop/src/main/java/io/openmessaging/benchmark/driver/kop/config/PulsarConfig.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.openmessaging.benchmark.driver.kop.config;
+
+public class PulsarConfig {
+
+    public String serviceUrl;
+
+    // producer configs
+    public boolean batchingEnabled = true;
+    public boolean blockIfQueueFull = true;
+    public int batchingMaxPublishDelayMs = 1;
+    public int batchingMaxBytes = 128 * 1024;
+    public int pendingQueueSize = 1000;
+    public int maxPendingMessagesAcrossPartitions = 50000;
+    public int batchingPartitionSwitchFrequencyByPublishDelay = 10;
+
+    // consumer configs
+    public int maxTotalReceiverQueueSizeAcrossPartitions = 50000;
+    public int receiverQueueSize = 1000;
+}

--- a/driver-kop/src/test/java/io/openmessaging/benchmark/driver/kop/KopBenchmarkDriverTest.java
+++ b/driver-kop/src/test/java/io/openmessaging/benchmark/driver/kop/KopBenchmarkDriverTest.java
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.openmessaging.benchmark.driver.kop;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Properties;
+import io.openmessaging.benchmark.driver.kop.config.ClientType;
+import io.openmessaging.benchmark.driver.kop.config.Config;
+import io.openmessaging.benchmark.driver.kop.config.PulsarConfig;
+import org.testng.annotations.Test;
+
+public class KopBenchmarkDriverTest {
+
+    @Test
+    public void testLoadDefaultConfig() throws URISyntaxException, IOException {
+        final URL url = getClass().getClassLoader().getResource("kop_required.yaml");
+        assertNotNull(url);
+
+        final Config config = KopBenchmarkDriver.loadConfig(new File(url.toURI()));
+        assertEquals(config.producerType, ClientType.PULSAR);
+        assertEquals(config.consumerType, ClientType.KAFKA);
+        assertEquals(config.pollTimeoutMs, 100);
+
+        final PulsarConfig pulsarConfig = config.pulsarConfig;
+        assertEquals(pulsarConfig.serviceUrl, "pulsar://localhost:6650");
+        assertTrue(pulsarConfig.batchingEnabled);
+        assertEquals(pulsarConfig.batchingMaxPublishDelayMs, 1);
+        assertEquals(pulsarConfig.batchingMaxBytes, 131072);
+        assertTrue(pulsarConfig.blockIfQueueFull);
+        assertEquals(pulsarConfig.pendingQueueSize, 1000);
+        assertEquals(pulsarConfig.maxPendingMessagesAcrossPartitions, 50000);
+        assertEquals(pulsarConfig.batchingPartitionSwitchFrequencyByPublishDelay, 10);
+        assertEquals(pulsarConfig.maxTotalReceiverQueueSizeAcrossPartitions, 50000);
+        assertEquals(pulsarConfig.receiverQueueSize, 1000);
+
+        assertEquals(config.getKafkaProperties().get("bootstrap.servers"), "localhost:9092");
+    }
+
+    @Test
+    public void testLoadCustomConfig() throws Exception {
+        final URL url = this.getClass().getClassLoader().getResource("kop_custom.yaml");
+        assertNotNull(url);
+
+        final Config config = KopBenchmarkDriver.loadConfig(new File(url.toURI()));
+        assertEquals(config.producerType, ClientType.KAFKA);
+        assertEquals(config.consumerType, ClientType.PULSAR);
+        assertEquals(config.pollTimeoutMs, 1000);
+
+        final PulsarConfig pulsarConfig = config.pulsarConfig;
+        assertEquals(pulsarConfig.serviceUrl, "pulsar+ssl://localhost:6651");
+        assertFalse(pulsarConfig.batchingEnabled);
+        assertEquals(pulsarConfig.batchingMaxPublishDelayMs, 10);
+        assertEquals(pulsarConfig.batchingMaxBytes, 1310720);
+        assertFalse(pulsarConfig.blockIfQueueFull);
+        assertEquals(pulsarConfig.pendingQueueSize, 10000);
+        assertEquals(pulsarConfig.maxPendingMessagesAcrossPartitions, 500000);
+        assertEquals(pulsarConfig.batchingPartitionSwitchFrequencyByPublishDelay, 100);
+        assertEquals(pulsarConfig.maxTotalReceiverQueueSizeAcrossPartitions, 500000);
+        assertEquals(pulsarConfig.receiverQueueSize, 10000);
+
+        final Properties props = config.getKafkaProperties();
+        assertEquals(props.size(), 3);
+        assertEquals(props.get("bootstrap.servers"), "localhost:9092");
+        assertEquals(props.get("linger.ms"), "1");
+        assertEquals(props.get("batch.size"), "1048576");
+    }
+
+    @Test
+    public void testLoadWrongKafkaConfig() throws Exception {
+        final URL url = this.getClass().getClassLoader().getResource("kop_wrong_kafka_config.yaml");
+        assertNotNull(url);
+
+        final Config config = KopBenchmarkDriver.loadConfig(new File(url.toURI()));
+        try {
+            config.getKafkaProperties();
+            fail();
+        } catch (IllegalArgumentException e) {
+            assertEquals(e.getMessage(), "bootstrap.servers is not set");
+        }
+    }
+}

--- a/driver-kop/src/test/resources/kop_custom.yaml
+++ b/driver-kop/src/test/resources/kop_custom.yaml
@@ -1,0 +1,47 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# The KoP config file whose optional items are customized with different values from default.
+
+name: Kafka-on-Pulsar
+driverClass: io.openmessaging.benchmark.driver.kop.KopBenchmarkDriver
+
+producerType: kafka
+consumerType: pulsar
+pollTimeoutMs: 1000
+
+# Pulsar configs
+pulsarConfig:
+  serviceUrl: pulsar+ssl://localhost:6651
+  # producer configs
+  batchingEnabled: false
+  batchingMaxPublishDelayMs: 10
+  batchingMaxBytes: 1310720
+  blockIfQueueFull: false
+  pendingQueueSize: 10000
+  maxPendingMessagesAcrossPartitions: 500000
+  # consumer configs
+  maxTotalReceiverQueueSizeAcrossPartitions: 500000
+  receiverQueueSize: 10000
+
+# Kafka configs
+kafkaConfig: |
+  bootstrap.servers=localhost:9092
+  linger.ms=1
+  batch.size=1048576

--- a/driver-kop/src/test/resources/kop_required.yaml
+++ b/driver-kop/src/test/resources/kop_required.yaml
@@ -1,0 +1,34 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# The KoP config file with required config items.
+
+name: Kafka-on-Pulsar
+driverClass: io.openmessaging.benchmark.driver.kop.KopBenchmarkDriver
+
+producerType: pulsar
+consumerType: kafka
+
+# Pulsar configs
+pulsarConfig:
+  serviceUrl: pulsar://localhost:6650
+
+# Kafka configs
+kafkaConfig: |
+  bootstrap.servers=localhost:9092

--- a/driver-kop/src/test/resources/kop_wrong_kafka_config.yaml
+++ b/driver-kop/src/test/resources/kop_wrong_kafka_config.yaml
@@ -1,0 +1,26 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# The KoP config file whose kafka config is wrong (without required configs)
+
+name: Kafka-on-Pulsar
+driverClass: io.openmessaging.benchmark.driver.kop.KopBenchmarkDriver
+
+kafkaConfig:
+  linger.ms=1

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
 		<module>driver-redis</module>
 		<module>package</module>
 		<module>docker</module>
+		<module>driver-kop</module>
 	</modules>
 
 


### PR DESCRIPTION
### Change log description
Contributed a new driver for KoP (aka. Kafka-on-Pulsar) (https://github.com/streamnative/kop).

### Purpose of the change

KoP enables Kafka applications access a Pulsar cluster. In addition, it also supports the interaction between a Kafka client and a Pulsar client. However, the benchmark cannot test this case, including Kafka producer with Pulsar consumer, or Pulsar producer with Kafka consumer. Therefore, this PR adds a driver to support this case.

### What the code does

- Add a `driver-kop` module, which supports a new configuration format to specify the client type (`kafka` or `pulsar`) of producers and consumers.
- Add a simple unit test for the new configuration format.
- Add three example configuration files under `driver-kop` directory.
- Reuse the existing benchmark producer and consumer from `driver-kafka` and `driver-pulsar`.
- For Pulsar consumer, a `KafkaPayloadProcessor`, which is introduced in Pulsar 2.9, is configured to support Pulsar consumer receiving messages with Kafka format. It's not required if we don't configure `entryFormat=kafka`, but in this case the performance would be terrible.

This PR doesn't add the scripts to deploy KoP in AWS or other cloud provider to avoid too many changes. We can add them in another PR.

### How to verify it

This PR doesn't add a deploy script to cloud service. But it can be verified easily via a Pulsar standalone with KoP enabled. See [here](https://github.com/streamnative/kop/blob/master/docs/kop.md#get-kop-protocol-handler) for quick start.

First, run a KoP standalone (Pulsar 2.9.1 and KoP 2.9.1.5) with following configs:

```properties
messagingProtocols=kafka
entryFormat=kafka
kafkaListeners=PLAINTEXT://127.0.0.1:9092
brokerEntryMetadataInterceptors=org.apache.pulsar.common.intercept.AppendIndexMetadataInterceptor
brokerDeleteInactiveTopicsEnabled=false
allowAutoTopicCreationType=partitioned
```

Then build the benchmark by `mvn clean install -DskipTests`, and run local worker:

```bash
./bin/benchmark -d driver-kop/kafka_to_pulsar.yaml -o kop.json workloads/1-topic-1-partition-100b.yaml
./bin/benchmark -d driver-kop/kafka_to_kafka.yaml -o kop.json workloads/1-topic-1-partition-100b.yaml
./bin/benchmark -d driver-kop/pulsar_to_kafka.yaml -o kop.json workloads/1-topic-1-partition-100b.yaml
```