### PR TITLE
Fixes #247 Fix Coordinated Omission

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/TestResult.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/TestResult.java
@@ -45,6 +45,15 @@ public class TestResult {
     public List<Double> publishLatency9999pct = new ArrayList<>();
     public List<Double> publishLatencyMax = new ArrayList<>();
 
+    public List<Double> publishDelayLatencyAvg = new ArrayList<>();
+    public List<Long> publishDelayLatency50pct = new ArrayList<>();
+    public List<Long> publishDelayLatency75pct = new ArrayList<>();
+    public List<Long> publishDelayLatency95pct = new ArrayList<>();
+    public List<Long> publishDelayLatency99pct = new ArrayList<>();
+    public List<Long> publishDelayLatency999pct = new ArrayList<>();
+    public List<Long> publishDelayLatency9999pct = new ArrayList<>();
+    public List<Long> publishDelayLatencyMax = new ArrayList<>();
+
     public double aggregatedPublishLatencyAvg;
     public double aggregatedPublishLatency50pct;
     public double aggregatedPublishLatency75pct;
@@ -54,7 +63,18 @@ public class TestResult {
     public double aggregatedPublishLatency9999pct;
     public double aggregatedPublishLatencyMax;
 
+    public double aggregatedPublishDelayLatencyAvg;
+    public long aggregatedPublishDelayLatency50pct;
+    public long aggregatedPublishDelayLatency75pct;
+    public long aggregatedPublishDelayLatency95pct;
+    public long aggregatedPublishDelayLatency99pct;
+    public long aggregatedPublishDelayLatency999pct;
+    public long aggregatedPublishDelayLatency9999pct;
+    public long aggregatedPublishDelayLatencyMax;
+
     public Map<Double, Double> aggregatedPublishLatencyQuantiles = new TreeMap<>();
+
+    public Map<Double, Long> aggregatedPublishDelayLatencyQuantiles = new TreeMap<>();
 
     // End to end latencies (from producer to consumer)
     // Latencies are expressed in milliseconds (without decimals)

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/UniformRateLimiter.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/UniformRateLimiter.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.openmessaging.benchmark.utils;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+import java.util.concurrent.locks.LockSupport;
+
+/**
+ * Provides a next operation time for rate limited operation streams.<br>
+ * The rate limiter is thread safe and can be shared by all threads.
+ */
+public final class UniformRateLimiter {
+
+    private static final AtomicLongFieldUpdater<UniformRateLimiter> V_TIME_UPDATER =
+            AtomicLongFieldUpdater.newUpdater(UniformRateLimiter.class, "virtualTime");
+    private static final AtomicLongFieldUpdater<UniformRateLimiter> START_UPDATER =
+            AtomicLongFieldUpdater.newUpdater(UniformRateLimiter.class, "start");
+    private static final double ONE_SEC_IN_NS = TimeUnit.SECONDS.toNanos(1);
+    private volatile long start = Long.MIN_VALUE;
+    private volatile long virtualTime;
+    private final double opsPerSec;
+    private final long intervalNs;
+
+    public UniformRateLimiter(final double opsPerSec) {
+        if (Double.isNaN(opsPerSec) || Double.isInfinite(opsPerSec)) {
+            throw new IllegalArgumentException("opsPerSec cannot be Nan or Infinite");
+        }
+        if (opsPerSec <= 0) {
+            throw new IllegalArgumentException("opsPerSec must be greater then 0");
+        }
+        this.opsPerSec = opsPerSec;
+        intervalNs = Math.round(ONE_SEC_IN_NS / opsPerSec);
+    }
+
+    public double getOpsPerSec() {
+        return opsPerSec;
+    }
+
+    public long getIntervalNs() {
+        return intervalNs;
+    }
+
+    public long acquire() {
+        final long currOpIndex = V_TIME_UPDATER.getAndIncrement(this);
+        long start = this.start;
+        if (start == Long.MIN_VALUE) {
+            start = System.nanoTime();
+            if (!START_UPDATER.compareAndSet(this, Long.MIN_VALUE, start)) {
+                start = this.start;
+                assert start != Long.MIN_VALUE;
+            }
+        }
+        return start + currOpIndex * intervalNs;
+    }
+
+    public static void uninterruptibleSleepNs(final long intendedTime) {
+        long sleepNs;
+        while ((sleepNs = (intendedTime - System.nanoTime())) > 0) {
+            LockSupport.parkNanos(sleepNs);
+        }
+    }
+}

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/DistributedWorkersEnsemble.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/DistributedWorkersEnsemble.java
@@ -200,6 +200,9 @@ public class DistributedWorkersEnsemble implements Worker {
                 stats.publishLatency.add(Histogram.decodeFromCompressedByteBuffer(
                         ByteBuffer.wrap(is.publishLatencyBytes), TimeUnit.SECONDS.toMicros(30)));
 
+                stats.publishDelayLatency.add(Histogram.decodeFromCompressedByteBuffer(
+                        ByteBuffer.wrap(is.publishDelayLatencyBytes), TimeUnit.SECONDS.toMicros(30)));
+
                 stats.endToEndLatency.add(Histogram.decodeFromCompressedByteBuffer(
                         ByteBuffer.wrap(is.endToEndLatencyBytes), TimeUnit.HOURS.toMicros(12)));
             } catch (ArrayIndexOutOfBoundsException | DataFormatException e) {
@@ -222,6 +225,15 @@ public class DistributedWorkersEnsemble implements Worker {
             } catch (Exception e) {
                 log.error("Failed to decode publish latency: {}",
                         ByteBufUtil.prettyHexDump(Unpooled.wrappedBuffer(is.publishLatencyBytes)));
+                throw new RuntimeException(e);
+            }
+
+            try {
+                stats.publishDelayLatency.add(Histogram.decodeFromCompressedByteBuffer(
+                        ByteBuffer.wrap(is.publishDelayLatencyBytes), TimeUnit.SECONDS.toMicros(30)));
+            } catch (Exception e) {
+                log.error("Failed to decode publish delay latency: {}",
+                          ByteBufUtil.prettyHexDump(Unpooled.wrappedBuffer(is.publishDelayLatencyBytes)));
                 throw new RuntimeException(e);
             }
 

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/WorkerHandler.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/WorkerHandler.java
@@ -136,6 +136,12 @@ public class WorkerHandler {
             histogramSerializationBuffer.get(stats.publishLatencyBytes);
 
             histogramSerializationBuffer.clear();
+            stats.publishDelayLatency.encodeIntoCompressedByteBuffer(histogramSerializationBuffer);
+            stats.publishDelayLatencyBytes = new byte[histogramSerializationBuffer.position()];
+            histogramSerializationBuffer.flip();
+            histogramSerializationBuffer.get(stats.publishDelayLatencyBytes);
+
+            histogramSerializationBuffer.clear();
             stats.endToEndLatency.encodeIntoCompressedByteBuffer(histogramSerializationBuffer);
             stats.endToEndLatencyBytes = new byte[histogramSerializationBuffer.position()];
             histogramSerializationBuffer.flip();
@@ -155,6 +161,12 @@ public class WorkerHandler {
             stats.publishLatencyBytes = new byte[histogramSerializationBuffer.position()];
             histogramSerializationBuffer.flip();
             histogramSerializationBuffer.get(stats.publishLatencyBytes);
+
+            histogramSerializationBuffer.clear();
+            stats.publishDelayLatency.encodeIntoCompressedByteBuffer(histogramSerializationBuffer);
+            stats.publishDelayLatencyBytes = new byte[histogramSerializationBuffer.position()];
+            histogramSerializationBuffer.flip();
+            histogramSerializationBuffer.get(stats.publishDelayLatencyBytes);
 
             histogramSerializationBuffer.clear();
             stats.endToEndLatency.encodeIntoCompressedByteBuffer(histogramSerializationBuffer);

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/commands/CumulativeLatencies.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/commands/CumulativeLatencies.java
@@ -31,6 +31,10 @@ public class CumulativeLatencies {
     public byte[] publishLatencyBytes;
 
     @JsonIgnore
+    public Histogram publishDelayLatency = new Histogram(TimeUnit.SECONDS.toMicros(60), 5);
+    public byte[] publishDelayLatencyBytes;
+
+    @JsonIgnore
     public Histogram endToEndLatency = new Histogram(TimeUnit.HOURS.toMicros(12), 5);
     public byte[] endToEndLatencyBytes;
 }

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/commands/PeriodStats.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/commands/PeriodStats.java
@@ -39,6 +39,11 @@ public class PeriodStats {
     public byte[] publishLatencyBytes;
 
     @JsonIgnore
+    public Histogram publishDelayLatency = new Histogram(TimeUnit.SECONDS.toMicros(60), 5);
+    public byte[] publishDelayLatencyBytes;
+
+
+    @JsonIgnore
     public Histogram endToEndLatency = new Histogram(TimeUnit.HOURS.toMicros(12), 5);
     public byte[] endToEndLatencyBytes;
 }

--- a/bin/create_charts.py
+++ b/bin/create_charts.py
@@ -43,6 +43,10 @@ def create_charts(test_results):
                      y_label='Latency (ms)',
                      time_series=[(x['driver'], x['publishLatency99pct']) for x in results])
 
+        create_chart(workload, 'Publish Delay latency 99pct',
+                     y_label='Latency (us)',
+                     time_series=[(x['driver'], x['publishDelayLatency99pct']) for x in results])
+
         create_chart(workload, 'Publish rate',
                      y_label='Rate (msg/s)',
                      time_series=[(x['driver'], x['publishRate']) for x in results])
@@ -62,6 +66,10 @@ def create_charts(test_results):
         create_quantile_chart(workload, 'Publish Latency Quantiles',
                               y_label='Latency (ms)',
                               time_series=[(x['driver'], x['aggregatedPublishLatencyQuantiles']) for x in results])
+
+        create_quantile_chart(workload, 'Publish Delay Latency Quantiles',
+                              y_label='Latency (us)',
+                              time_series=[(x['driver'], x['aggregatedPublishDelayLatencyQuantiles']) for x in results])
 
         create_quantile_chart(workload, 'End To End Latency Quantiles',
                               y_label='Latency (ms)',


### PR DESCRIPTION
This is fixing Coordinated Omission by providing an additional metric ie `producer delay`: this metric should capture the delay while producing the load due to "some reason" (see https://github.com/openmessaging/benchmark/issues/247) preventing the generator to keep up with the expected configured rate.

This change is using a more appropriate rate limiter (different from the one of Guava) that's aware of the expected schedule.

The current strategy to find the sustainable rate (according to a specific backlog) is fine-ish to prevent it to happen, but actual measurements should be taken to check what happen during the actual test too.