### PR TITLE
Use the latest apache pulsar grafana dashboard

### DIFF
--- a/driver-pulsar/deploy/ssd/templates/pulsar-dashboard.service
+++ b/driver-pulsar/deploy/ssd/templates/pulsar-dashboard.service
@@ -8,7 +8,7 @@ Requires=prometheus.service
 [Service]
 WorkingDirectory=/opt/pulsar
 ExecStartPre=/usr/bin/docker pull streamnative/apache-pulsar-grafana-dashboard:latest
-ExecStart=/usr/bin/docker run --restart=always --name=systemd_pulsar_dashboard -p3000:3000 -e PULSAR_PROMETHEUS_URL=http://{{ hostvars[groups['prometheus'][0]].private_ip }}:9090/ -e PULSAR_CLUSTER=local streamnative/apache-pulsar-grafana-dashboard:0.0.8
+ExecStart=/usr/bin/docker run --restart=always --name=systemd_pulsar_dashboard -p3000:3000 -e PULSAR_PROMETHEUS_URL=http://{{ hostvars[groups['prometheus'][0]].private_ip }}:9090/ -e PULSAR_CLUSTER=local streamnative/apache-pulsar-grafana-dashboard:latest
 ExecStop=/usr/bin/docker stop systemd_pulsar_dashboard
 ExecStopPost=/usr/bin/docker rm -f systemd_pulsar_dashboard
 ExecReload=/usr/bin/docker restart systemd_pulsar_dashboard


### PR DESCRIPTION
### Motivation

Currently, we are using pull the latest apache pulsar grafana dashboard, but using 0.0.8 to run it, we should run the latest version of apache pulsar grafana dashboard.

### Modifications

* Use the latest apache pulsar grafana dashboard