### PR TITLE
[Pulsar] Add ansible playbook to restart broker

### DIFF
--- a/driver-pulsar/README.md
+++ b/driver-pulsar/README.md
@@ -50,3 +50,15 @@ protocol_handlers:
 ```
 
 It will download KoP and MoP from the given URLs. Then, the configuration templates will be formatted and appended to the `broker.conf`. The `conf` field is the name of the configuration template, which must be put under `templates` directory.
+
+### Restart the brokers with new configurations
+
+You can change the configuration files and then restart the cluster by executing the following command.
+
+```bash
+TF_STATE=. ansible-playbook \
+  --user ec2-user \
+  --inventory `which terraform-inventory` \
+  -e @extra_vars.yaml \
+  restart_broker.yaml
+```

--- a/driver-pulsar/deploy/ssd/restart_broker.yaml
+++ b/driver-pulsar/deploy/ssd/restart_broker.yaml
@@ -1,0 +1,85 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+- name: Initialize variables
+  hosts: all
+  connection: ssh
+  tasks:
+    - set_fact:
+        private_ip: "{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}"
+        zookeeperServers: "{{ groups['zookeeper'] | map('extract', hostvars, ['ansible_default_ipv4', 'address']) | map('regex_replace', '^(.*)$', '\\1:2181') | join(',') }}"
+
+- name: Restart brokers with new configurations
+  hosts: pulsar
+  become: true
+  tasks:
+    - set_fact:
+        max_heap_memory: "{{ pulsar_max_heap_memory | default('16g') }}"
+        max_direct_memory: "{{ pulsar_max_direct_memory | default('48g') }}"
+    - systemd:
+        state: stopped
+        name: pulsar
+    - name: Set up pulsar.service
+      template:
+        src: templates/pulsar.service
+        dest: /etc/systemd/system/pulsar.service
+    - name: Set up pulsar_env.sh
+      template:
+        src: templates/pulsar_env.sh
+        dest: /opt/pulsar/conf/pulsar_env.sh
+    - name: Set up broker.conf
+      template:
+        src: templates/broker.conf
+        dest: /opt/pulsar/conf/broker.conf
+    - name: Set up configurations of protocol handlers
+      template:
+        src: "templates/{{ item.conf }}"
+        dest: "/opt/pulsar/conf/{{ item.conf }}"
+      loop: "{{ protocol_handlers }}"
+      when: protocol_handlers is defined
+    - set_fact:
+        protocols: "{{ protocols | default([]) + [ item.protocol ] }}"
+      loop: "{{ protocol_handlers }}"
+      when: protocol_handlers is defined
+    - name: Enable protocol handlers
+      lineinfile:
+        path: /opt/pulsar/conf/broker.conf
+        line: "messagingProtocols={{ protocols | join(',') }}"
+    - name: Read configurations of all protocol handlers
+      shell: |
+        grep -v "^#" "{{ '/opt/pulsar/conf/' + item.conf }}"
+      loop: "{{ protocol_handlers }}"
+      when: protocol_handlers is defined
+      register: conf_files
+    - name: Read configurations of all protocol handlers
+      shell: |
+        grep -v "^#" "{{ '/opt/pulsar/conf/' + item.conf }}"
+      loop: "{{ protocol_handlers }}"
+      when: protocol_handlers is defined
+      register: conf_files
+    - name: Update broker.conf for protocol handlers
+      lineinfile:
+        path: /opt/pulsar/conf/broker.conf
+        line: "{{ item.stdout_lines | join('\n') }}"
+      loop: "{{ conf_files.results }}"
+      when: conf_files is defined
+    - systemd:
+        state: started
+        daemon_reload: yes
+        name: pulsar


### PR DESCRIPTION
### Motivation

Sometimes we might want to change some configuration items and restart the broker. In this case, we need to login the remote machines, modify the configuration files and then restart the `systemd` service.

### Modifications

Add an ansible playbook `restart_broker.yaml` to apply the configuration changes just by a single command.
