### PR TITLE
[Pravega Driver] [Draft] Update dependencies for Pravega 0.12

### DIFF
--- a/driver-pravega/pom.xml
+++ b/driver-pravega/pom.xml
@@ -30,9 +30,9 @@
     <artifactId>driver-pravega</artifactId>
 
     <properties>
-        <!--Specify pravegaVersion in properties or use default: 0.10.0-->
-        <!--Provide Pravega version for build: mvn clean install  "-DpravegaVersion=0.9.0-2766.2515791-SNAPSHOT" -DskipTests=true -Dlicense.skip=true-->
-        <pravegaVersion>0.10.1</pravegaVersion>
+        <!--Specify pravegaVersion in properties or use default: 0.11.0-->
+        <!--Provide Pravega version for build: mvn clean install  "-DpravegaVersion=0.11.0-dded0f1f0-SNAPSHOT" -DskipTests=true -Dlicense.skip=true-->
+        <pravegaVersion>0.11.0</pravegaVersion>
     </properties>
 
     <repositories>
@@ -68,7 +68,15 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-all</artifactId>
-            <version>1.36.0</version>
+            <!-- NOTE: Please, use 1.36.0 for Pravega Client 0.10.* builds -->
+            <!-- NOTE: Please, use 1.36.2 for Pravega Client 0.11.* builds -->
+            <version>1.39.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative-boringssl-static</artifactId>
+            <version>2.0.39.Final</version>
         </dependency>
 
         <dependency>

--- a/driver-pravega/pom.xml
+++ b/driver-pravega/pom.xml
@@ -30,9 +30,9 @@
     <artifactId>driver-pravega</artifactId>
 
     <properties>
-        <!--Specify pravegaVersion in properties or use default: 0.11.0-->
-        <!--Provide Pravega version for build: mvn clean install  "-DpravegaVersion=0.11.0-dded0f1f0-SNAPSHOT" -DskipTests=true -Dlicense.skip=true-->
-        <pravegaVersion>0.11.0</pravegaVersion>
+        <!--Specify pravegaVersion in properties or use default: 0.12.0-->
+        <!--Provide Pravega version for build: mvn clean install  "-DpravegaVersion=0.12.0-3080.e05a7fb-SNAPSHOT" -DskipTests=true -Dlicense.skip=true-->
+        <pravegaVersion>0.12.0</pravegaVersion>
     </properties>
 
     <repositories>
@@ -68,8 +68,7 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-all</artifactId>
-            <!-- NOTE: Please, use 1.36.0 for Pravega Client 0.10.* builds -->
-            <!-- NOTE: Please, use 1.36.2 for Pravega Client 0.11.* builds -->
+            <!-- NOTE: Please, use 1.36.0 for Pravega Client 0.10.*, 1.36.2 for Pravega 0.11.* builds -->
             <version>1.39.0</version>
         </dependency>
 


### PR DESCRIPTION
Hello,
This PR resolves https://github.com/openmessaging/benchmark/issues/258
I would like to mention that [Pravega 0.12.0](https://github.com/pravega/pravega) is currently under development, thus I would like the PR to remain in "draft" status until it would be officially release.
At the same time, it might be a useful source of information for people who would like to try OpenMessaging benchmark with recent versions of Pravega - they would know which parameters (dependencies) should be changed in order to build it with matching client libraries. 