### PR TITLE
[issue #275] fix waiting for consumers to be ready

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
@@ -171,7 +171,7 @@ public class WorkloadGenerator implements AutoCloseable {
         }
 
         if (System.currentTimeMillis() >= end) {
-            log.warn("Timed out waiting for consumers to be ready");
+            throw new RuntimeException("Timed out waiting for consumers to be ready");
         }
         else {
             log.info("All consumers are ready");

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
@@ -154,7 +154,9 @@ public class WorkloadGenerator implements AutoCloseable {
         // In this case we just publish 1 message and then wait for consumers to receive the data
         worker.probeProducers();
 
-	while (true) {
+	    long start = System.currentTimeMillis();
+        long end = start + 60 * 1000;
+        while (System.currentTimeMillis() < end) {
             CountersStats stats = worker.getCountersStats();
 	    
             if (stats.messagesReceived < expectedMessages) {
@@ -168,7 +170,12 @@ public class WorkloadGenerator implements AutoCloseable {
             }
         }
 
-        log.info("All consumers are ready");
+        if (System.currentTimeMillis() >= end) {
+            log.warn("Timed out waiting for consumers to be ready");
+        }
+        else {
+            log.info("All consumers are ready");
+        }        
     }
 
     /**


### PR DESCRIPTION
Following the issue #275 already closed, I believe that it is better to throw an exception when the timeout is reached instead of logging a warning.

I got an issue after the time out is reached but the test is launched. After the test execution when calling `stop-all` it throws an exception because the time out was a warning telling us that something was not correctly set up.

```
15:56:08  13:56:08.822 [main] INFO - Pub rate    15.1 msg/s /  7.5 MB/s | Cons rate     9.9 msg/s /  5.0 MB/s | Backlog:  4.7 K | Pub Latency (ms) avg: 20.1 - 50%: 14.8 - 99%: 89.2 - 99.9%: 122.4 - Max: 122.4 | Pub Delay Latency (us) avg: 134.7 - 50%: 132.0 - 99%: 200.0 - 99.9%: 209.0 - Max: 209.0
15:56:21  13:56:19.002 [main] INFO - Pub rate    14.9 msg/s /  7.5 MB/s | Cons rate    10.3 msg/s /  5.2 MB/s | Backlog:  4.8 K | Pub Latency (ms) avg: 25.2 - 50%: 14.9 - 99%: 102.0 - 99.9%: 139.9 - Max: 139.9 | Pub Delay Latency (us) avg: 132.0 - 50%: 130.0 - 99%: 205.0 - 99.9%: 215.0 - Max: 215.0
15:56:31  13:56:29.182 [main] INFO - Pub rate    15.0 msg/s /  7.5 MB/s | Cons rate    10.4 msg/s /  5.2 MB/s | Backlog:  4.8 K | Pub Latency (ms) avg: 20.5 - 50%: 14.3 - 99%: 93.2 - 99.9%: 93.8 - Max: 93.8 | Pub Delay Latency (us) avg: 134.1 - 50%: 131.0 - 99%: 209.0 - 99.9%: 251.0 - Max: 251.0
15:56:31  13:56:29.372 [main] INFO - ----- Aggregated Pub Latency (ms) avg: 22.3 - 50%: 14.7 - 95%: 67.0 - 99%: 116.5 - 99.9%: 237.0 - 99.99%: 500.5 - Max: 743.4 | Pub Delay (us)  avg: 152.2 - 50%: 133.0 - 95%: 176.0 - 99%: 216.0 - 99.9%: 518.0 - 99.99%: 58451.0 - Max: 91599.0
15:56:31  13:56:29.696 [AsyncHttpClient-3-3] ERROR - Failed to do HTTP post request to http://10.0.1.3:8080/stop-all -- code: 500
15:56:31  13:56:29.697 [main] ERROR - Failed to run the workload '1 producer(s) / 1 consumers on 1 topic(s)' for driver 'driver-kafka/kafka.yaml'
15:56:31  java.util.concurrent.CompletionException: java.lang.IllegalArgumentException
15:56:31  	at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:314) ~[?:?]
15:56:31  	at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:319) ~[?:?]
15:56:31  	at java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:645) ~[?:?]
15:56:31  	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506) ~[?:?]
15:56:31  	at java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2073) ~[?:?]
```