### PR TITLE
Create topics as a batch to minimise requests

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/LocalWorker.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/LocalWorker.java
@@ -16,6 +16,7 @@ package io.openmessaging.benchmark.worker;
 import static io.openmessaging.benchmark.utils.UniformRateLimiter.*;
 import static java.util.stream.Collectors.toList;
 
+import io.openmessaging.benchmark.driver.BenchmarkDriver.TopicInfo;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -28,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAdder;
 
 import io.openmessaging.benchmark.utils.UniformRateLimiter;
+import java.util.stream.IntStream;
 import org.HdrHistogram.Recorder;
 import org.apache.bookkeeper.stats.Counter;
 import org.apache.bookkeeper.stats.NullStatsLogger;
@@ -142,23 +144,22 @@ public class LocalWorker implements Worker, ConsumerCallback {
 
     @Override
     public List<String> createTopics(TopicsInfo topicsInfo) {
-        List<CompletableFuture<Void>> futures = new ArrayList<>();
-
         Timer timer = new Timer();
 
+        List<TopicInfo> topicInfos = IntStream.range(0, topicsInfo.numberOfTopics)
+                .mapToObj(i -> new TopicInfo(generateTopicName(i), topicsInfo.numberOfPartitionsPerTopic))
+                .collect(toList());
 
-        List<String> topics = new ArrayList<>();
-        for (int i = 0; i < topicsInfo.numberOfTopics; i++) {
-            String topicPrefix = benchmarkDriver.getTopicNamePrefix();
-            String topic = String.format("%s-%s-%04d", topicPrefix, RandomGenerator.getRandomString(), i);
-            topics.add(topic);
-            futures.add(benchmarkDriver.createTopic(topic, topicsInfo.numberOfPartitionsPerTopic));
-        }
+        benchmarkDriver.createTopics(topicInfos).join();
 
-        futures.forEach(CompletableFuture::join);
+        List<String> topics = topicInfos.stream().map(TopicInfo::getTopic).collect(toList());
 
         log.info("Created {} topics in {} ms", topics.size(), timer.elapsedMillis());
         return topics;
+    }
+
+    private String generateTopicName(int i) {
+        return String.format("%s-%s-%04d", benchmarkDriver.getTopicNamePrefix(), RandomGenerator.getRandomString(), i);
     }
 
     @Override

--- a/driver-api/src/main/java/io/openmessaging/benchmark/driver/BenchmarkDriver.java
+++ b/driver-api/src/main/java/io/openmessaging/benchmark/driver/BenchmarkDriver.java
@@ -15,6 +15,7 @@ package io.openmessaging.benchmark.driver;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.apache.bookkeeper.stats.StatsLogger;
 
@@ -45,6 +46,17 @@ public interface BenchmarkDriver extends AutoCloseable {
     CompletableFuture<Void> createTopic(String topic, int partitions);
 
     /**
+     * Create a list of new topics with the given number of partitions
+     */
+    default CompletableFuture<Void> createTopics(List<TopicInfo> topicInfos) {
+        @SuppressWarnings("unchecked")
+        CompletableFuture<Void>[] futures =  topicInfos.stream()
+                .map(topicInfo -> createTopic(topicInfo.getTopic(), topicInfo.getPartitions()))
+                .toArray(CompletableFuture[]::new);
+        return CompletableFuture.allOf(futures);
+    }
+
+    /**
      * Create a producer for a given topic
      */
     CompletableFuture<BenchmarkProducer> createProducer(String topic);
@@ -64,4 +76,22 @@ public interface BenchmarkDriver extends AutoCloseable {
         String topic,
         String subscriptionName,
         ConsumerCallback consumerCallback);
+
+    class TopicInfo {
+        private final String topic;
+        private final int partitions;
+
+        public TopicInfo(String topic, int partitions) {
+            this.topic = topic;
+            this.partitions = partitions;
+        }
+
+        public String getTopic() {
+            return topic;
+        }
+
+        public int getPartitions() {
+            return partitions;
+        }
+    }
 }

--- a/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/KafkaBenchmarkDriver.java
+++ b/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/KafkaBenchmarkDriver.java
@@ -110,8 +110,7 @@ public class KafkaBenchmarkDriver implements BenchmarkDriver {
 
     @Override
     public CompletableFuture<Void> createTopic(String topic, int partitions) {
-        NewTopic newTopic = createNewTopic(new TopicInfo(topic, partitions));
-        return admin.createTopics(Collections.singletonList(newTopic)).all().toCompletionStage().toCompletableFuture();
+        return createTopics(Collections.singletonList(new TopicInfo(topic, partitions)));
     }
 
     @Override


### PR DESCRIPTION
Add support for batching of topic creation in `BenchmarkDriver` to be able to take advantage of Kafka's admin functionality that takes a list of topics in a single request.