### PR TITLE
Change zookeeper node type to i3en.2xlarge for multi-topics test

### DIFF
--- a/driver-kafka/deploy/ssd-deployment/deploy.yaml
+++ b/driver-kafka/deploy/ssd-deployment/deploy.yaml
@@ -62,6 +62,29 @@
     - name: Reboot the machine with all defaults
       reboot:
 
+- name: Format and mount disks for Zookeeper hosts
+  hosts: zookeeper
+  connection: ssh
+  become: true
+  tasks:
+    - name: Format disks
+      filesystem:
+        fstype: xfs
+        dev: '{{ item }}'
+      with_items:
+        - '/dev/nvme1n1'
+        - '/dev/nvme2n1'
+    - name: Mount disks
+      mount:
+        path: "{{ item.path }}"
+        src: "{{ item.src }}"
+        fstype: xfs
+        opts: defaults,noatime,nodiscard
+        state: mounted
+      with_items:
+        - { path: "/mnt/zookeeper/logs", src: "/dev/nvme1n1" }
+        - { path: "/mnt/zookeeper/data", src: "/dev/nvme2n1" }
+
 - name: Kafka setup
   hosts: all
   connection: ssh
@@ -103,15 +126,12 @@
   tasks:
     - set_fact:
         zid: "{{ groups['zookeeper'].index(inventory_hostname) }}"
-    - file:
-        path: "/opt/kafka/data/zookeeper"
-        state: directory
     - template:
         src: "templates/zookeeper.properties"
         dest: "/opt/kafka/config/zookeeper.properties"
     - template:
         src: templates/myid
-        dest: "/opt/kafka/data/zookeeper/myid"
+        dest: "/mnt/zookeeper/data/myid"
     - template:
         src: "templates/zookeeper.service"
         dest: "/etc/systemd/system/zookeeper.service"

--- a/driver-kafka/deploy/ssd-deployment/templates/zookeeper.properties
+++ b/driver-kafka/deploy/ssd-deployment/templates/zookeeper.properties
@@ -21,7 +21,8 @@ initLimit=10
 # sending a request and getting an acknowledgement
 syncLimit=5
 # the directory where the snapshot is stored.
-dataDir=data/zookeeper
+dataLogDir=/mnt/zookeeper/logs
+dataDir=/mnt/zookeeper/data
 # the port at which the clients will connect
 clientPort=2181
 # the maximum number of client connections.

--- a/driver-kafka/deploy/ssd-deployment/templates/zookeeper.service
+++ b/driver-kafka/deploy/ssd-deployment/templates/zookeeper.service
@@ -3,6 +3,7 @@ Description=ZooKeeper
 After=network.target
 
 [Service]
+Environment='KAFKA_HEAP_OPTS=-Xms32g -Xmx32g'
 ExecStart=/opt/kafka/bin/zookeeper-server-start.sh config/zookeeper.properties
 WorkingDirectory=/opt/kafka
 RestartSec=1s

--- a/driver-kafka/deploy/ssd-deployment/terraform.tfvars
+++ b/driver-kafka/deploy/ssd-deployment/terraform.tfvars
@@ -5,7 +5,7 @@ ami             = "ami-08970fb2e5767e3b8" // RHEL-8
 
 instance_types = {
   "kafka"     = "i3en.6xlarge"
-  "zookeeper" = "t2.xlarge"
+  "zookeeper" = "i3en.2xlarge"
   "client"    = "m5n.8xlarge"
 }
 

--- a/driver-pulsar/deploy/ssd/deploy.yaml
+++ b/driver-pulsar/deploy/ssd/deploy.yaml
@@ -43,6 +43,29 @@
           remote: yes
       when: prometheus_binary is not defined
 
+- name: Format and mount disks for Zookeeper hosts
+  hosts: zookeeper
+  connection: ssh
+  become: true
+  tasks:
+    - name: Format disks
+      filesystem:
+        fstype: xfs
+        dev: '{{ item }}'
+      with_items:
+        - "{{ disk_dev[0] }}"
+        - "{{ disk_dev[1] }}"
+    - name: Mount disks
+      mount:
+        path: "{{ item.path }}"
+        src: "{{ item.src }}"
+        fstype: xfs
+        opts: defaults,noatime,nodiscard
+        state: mounted
+      with_items:
+        - { path: "/mnt/zookeeper/logs", src: "{{ disk_dev[0] }}" }
+        - { path: "/mnt/zookeeper/data", src: "{{ disk_dev[1] }}" }
+
 - name: Format and mount disks for Pulsar/BookKeeper hosts
   hosts: pulsar
   connection: ssh
@@ -195,7 +218,7 @@
   tasks:
     - set_fact:
         zid: "{{ groups['zookeeper'].index(inventory_hostname) }}"
-        max_heap_memory: "{{ zookeeper_max_heap_memory | default('10G') }}"
+        max_heap_memory: "{{ zookeeper_max_heap_memory | default('32G') }}"
         max_direct_memory: "{{ zookeeper_max_direct_memory | default('2G') }}"
     - file:
         path: "/opt/pulsar/{{ item }}"
@@ -210,7 +233,7 @@
         dest: "/opt/pulsar/conf/zookeeper.conf"
     - template:
         src: templates/myid
-        dest: "/opt/pulsar/data/zookeeper/myid"
+        dest: "/mnt/zookeeper/data/myid"
     - template:
         src: "templates/zookeeper.service"
         dest: "/etc/systemd/system/zookeeper.service"

--- a/driver-pulsar/deploy/ssd/templates/zoo.cfg
+++ b/driver-pulsar/deploy/ssd/templates/zoo.cfg
@@ -21,7 +21,8 @@ initLimit=10
 # sending a request and getting an acknowledgement
 syncLimit=5
 # the directory where the snapshot is stored.
-dataDir=data/zookeeper
+dataLogDir=/mnt/zookeeper/logs
+dataDir=/mnt/zookeeper/data
 # the port at which the clients will connect
 clientPort=2181
 # the maximum number of client connections.

--- a/driver-pulsar/deploy/ssd/terraform.tfvars
+++ b/driver-pulsar/deploy/ssd/terraform.tfvars
@@ -5,7 +5,7 @@ ami             = "ami-08970fb2e5767e3b8" // RHEL-8
 
 instance_types = {
   "pulsar"     = "i3en.6xlarge"
-  "zookeeper"  = "t2.xlarge"
+  "zookeeper"  = "i3en.2xlarge"
   "client"     = "m5n.8xlarge"
   "prometheus" = "t2.large"
 }


### PR DESCRIPTION
### Modification

- Change zookeeper node type to i3en.2xlarge for multi-topics test
- Use separated disks for zookeeper logs and data
- Increase heap memory to 32G to avoid zookeeper OOM during the multi-topics test

### Verification

I have tested the deployment for both Kafka and Pulsar on AWS.