### PR TITLE
Revert "Bump jetty-server from 9.4.42.v20210604 to 10.0.10 in /benchmark-framework"

### DIFF
--- a/benchmark-framework/pom.xml
+++ b/benchmark-framework/pom.xml
@@ -194,7 +194,7 @@
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-server</artifactId>
-			<version>10.0.10</version>
+			<version>9.4.42.v20210604</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Reverts openmessaging/benchmark#274