### PR TITLE
[RabbitMQ] Introduce AZ var, default to us-west-2a

### DIFF
--- a/driver-rabbitmq/README.md
+++ b/driver-rabbitmq/README.md
@@ -69,6 +69,7 @@ There's a handful of configurable parameters related to the Terraform deployment
 Variable | Description | Default
 :--------|:------------|:-------
 `region` | The AWS region in which the RabbitMQ cluster will be deployed | `us-west-2`
+`az` | The availability zone in which the RabbitMQ cluster will be deployed | `us-west-2a`
 `public_key_path` | The path to the SSH public key that you've generated | `~/.ssh/rabbitmq_aws.pub`
 `ami` | The [Amazon Machine Image](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html) (AWI) to be used by the cluster's machines | [`ami-9fa343e7`](https://access.redhat.com/articles/3135091)
 `instance_types` | The EC2 instance types used by the various components | `i3.4xlarge` (RabbitMQ brokers), `c4.8xlarge` (benchmarking client)
@@ -77,10 +78,11 @@ Variable | Description | Default
 
 ### Running the Ansible playbook
 
-With the appropriate infrastructure in place, you can install and start the RabbitMQ cluster using Ansible with just one command:
+With the appropriate infrastructure in place, you can install and start the RabbitMQ cluster using Ansible with just one command.
+Note that a `TFSTATE` environment must point to the folder in which the `tf.state` file is located. 
 
 ```bash
-$ ansible-playbook \
+$ TF_STATE=. ansible-playbook \
   --user ec2-user \
   --inventory `which terraform-inventory` \
   deploy.yaml

--- a/driver-rabbitmq/README.md
+++ b/driver-rabbitmq/README.md
@@ -69,7 +69,6 @@ There's a handful of configurable parameters related to the Terraform deployment
 Variable | Description | Default
 :--------|:------------|:-------
 `region` | The AWS region in which the RabbitMQ cluster will be deployed | `us-west-2`
-`az` | The availability zone in which the RabbitMQ cluster will be deployed | `us-west-2a`
 `public_key_path` | The path to the SSH public key that you've generated | `~/.ssh/rabbitmq_aws.pub`
 `ami` | The [Amazon Machine Image](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html) (AWI) to be used by the cluster's machines | [`ami-9fa343e7`](https://access.redhat.com/articles/3135091)
 `instance_types` | The EC2 instance types used by the various components | `i3.4xlarge` (RabbitMQ brokers), `c4.8xlarge` (benchmarking client)
@@ -78,11 +77,10 @@ Variable | Description | Default
 
 ### Running the Ansible playbook
 
-With the appropriate infrastructure in place, you can install and start the RabbitMQ cluster using Ansible with just one command.
-Note that a `TFSTATE` environment must point to the folder in which the `tf.state` file is located. 
+With the appropriate infrastructure in place, you can install and start the RabbitMQ cluster using Ansible with just one command:
 
 ```bash
-$ TF_STATE=. ansible-playbook \
+$ ansible-playbook \
   --user ec2-user \
   --inventory `which terraform-inventory` \
   deploy.yaml

--- a/driver-rabbitmq/deploy/provision-rabbitmq-aws.tf
+++ b/driver-rabbitmq/deploy/provision-rabbitmq-aws.tf
@@ -22,6 +22,7 @@ variable "num_instances" {
 }
 
 variable "region" {}
+variable "az" {}
 variable "ami" {}
 
 provider "aws" {
@@ -54,6 +55,7 @@ resource "aws_subnet" "benchmark_subnet" {
   vpc_id                  = "${aws_vpc.benchmark_vpc.id}"
   cidr_block              = "10.0.0.0/24"
   map_public_ip_on_launch = true
+  availability_zone       = var.az
 }
 
 resource "aws_security_group" "benchmark_security_group" {

--- a/driver-rabbitmq/deploy/provision-rabbitmq-aws.tf
+++ b/driver-rabbitmq/deploy/provision-rabbitmq-aws.tf
@@ -55,7 +55,7 @@ resource "aws_subnet" "benchmark_subnet" {
   vpc_id                  = "${aws_vpc.benchmark_vpc.id}"
   cidr_block              = "10.0.0.0/24"
   map_public_ip_on_launch = true
-  availability_zone       = var.az
+  availability_zone       = "${var.az}"
 }
 
 resource "aws_security_group" "benchmark_security_group" {

--- a/driver-rabbitmq/deploy/terraform.tfvars
+++ b/driver-rabbitmq/deploy/terraform.tfvars
@@ -1,5 +1,6 @@
 public_key_path = "~/.ssh/rabbitmq_aws.pub"
 region          = "us-west-2"
+az              = "us-west-2a"
 ami             = "ami-9fa343e7" // RHEL-7.4
 
 instance_types = {


### PR DESCRIPTION
# Motivation

Some AZs do not contain the instances type used by the RMQ benchmark client. Therefore it is necessary to explicitly set the AZ to one that does.

# Changes

* Introduce AZ var
* Default to `us-west-2a`