### PR TITLE
Improve visibility and stability of benchmark execution

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
@@ -158,10 +158,11 @@ public class WorkloadGenerator implements AutoCloseable {
         long end = start + 60 * 1000;
         while (System.currentTimeMillis() < end) {
             CountersStats stats = worker.getCountersStats();
-	    
+
+            log.info("Sent: {}, Received: {}", stats.messagesSent, stats.messagesReceived);
             if (stats.messagesReceived < expectedMessages) {
                 try {
-                    Thread.sleep(100);
+                    Thread.sleep(2_000);
                 } catch (InterruptedException e) {
                     throw new RuntimeException(e);
                 }

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
@@ -159,7 +159,7 @@ public class WorkloadGenerator implements AutoCloseable {
         while (System.currentTimeMillis() < end) {
             CountersStats stats = worker.getCountersStats();
 
-            log.info("Sent: {}, Received: {}", stats.messagesSent, stats.messagesReceived);
+            log.info("Waiting for topics to be ready -- Sent: {}, Received: {}", stats.messagesSent, stats.messagesReceived);
             if (stats.messagesReceived < expectedMessages) {
                 try {
                     Thread.sleep(2_000);

--- a/benchmark-framework/src/main/resources/log4j2.yaml
+++ b/benchmark-framework/src/main/resources/log4j2.yaml
@@ -22,12 +22,21 @@ Configuration:
       target: SYSTEM_OUT
       PatternLayout:
         Pattern: "%d{HH:mm:ss.SSS} [%t] %-4level - %msg%n"
-        
+    RollingFile:
+      name: RollingFile
+      fileName: benchmark-worker.log
+      filePattern: benchmark-worker.log.%d{yyyy-MM-dd-hh-mm-ss}.gz
+      PatternLayout:
+        Pattern: "%d{HH:mm:ss.SSS} [%t] %-4level - %msg%n"
+      Policies:
+        SizeBasedTriggeringPolicy:
+          size: 100MB
+      DefaultRollOverStrategy:
+        max: 10
   Loggers: 
     Root:
       level: info
       additivity: false
       AppenderRef:
-        ref: Console
-        
-       
+        - ref: Console
+        - ref: RollingFile

--- a/driver-kafka/deploy/ssd-deployment/ansible.cfg
+++ b/driver-kafka/deploy/ssd-deployment/ansible.cfg
@@ -6,3 +6,6 @@ private_key_file=~/.ssh/kafka_aws
 become=true
 become_method='sudo'
 become_user='root'
+
+[ssh_connection]
+ssh_args=-o ServerAliveInterval=60

--- a/driver-kafka/kafka-throughput.yaml
+++ b/driver-kafka/kafka-throughput.yaml
@@ -25,7 +25,8 @@ topicConfig: |
 
 commonConfig: |
   bootstrap.servers=localhost:9092
-  default.api.timeout.ms=600000
+  default.api.timeout.ms=1200000
+  request.timeout.ms=1200000
 
 producerConfig: |
   acks=all


### PR DESCRIPTION
## Motivation

As a new user running benchmarks sometimes it's not clear what's happening at
any given moment. It's useful to add extra logging to give more feedback to the
user. Additionally, the configuration could be more stable under larger
workloads.

## Changes

* During startup, to test everything is ready a single message is sent from each
  producer. The send and received counts are now logged every 2 seconds
* Added rolling-file logging config to allow the user to ssh onto other workers
  to check the logs
* Added ServerAliveInterval=60 to the ansible configuration so it's more stable
  during long running tasks
* Added request.timeout.ms=1200000 to make Kafka API calls more stable until
  larger workloads
* Added periodic logging of Kafka topic creation status
* In DistributedWorkersEnsemble, the use of Pulsar's FutureUtil has been
  replaced with standard CompletableFuture methods