### PR TITLE
Add a shutdownhook to stop all workers

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Benchmark.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Benchmark.java
@@ -128,6 +128,7 @@ public class Benchmark {
 
         if (arguments.workers != null && !arguments.workers.isEmpty()) {
             worker = new DistributedWorkersEnsemble(arguments.workers, arguments.extraConsumers);
+            Runtime.getRuntime().addShutdownHook(new Thread(worker::stopAll));
         } else {
             // Use local worker implementation
             worker = new LocalWorker();

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/LocalWorker.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/LocalWorker.java
@@ -355,7 +355,7 @@ public class LocalWorker implements Worker, ConsumerCallback {
     }
 
     @Override
-    public void stopAll() throws IOException {
+    public void stopAll() {
         testCompleted = true;
         consumersArePaused = false;
 

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/Worker.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/Worker.java
@@ -52,5 +52,5 @@ public interface Worker extends AutoCloseable {
 
     void resetStats() throws IOException;
 
-    void stopAll() throws IOException;
+    void stopAll();
 }


### PR DESCRIPTION
## Motivation

If one needs to prematurely terminate a benchmark workload, for example with a Ctrl-C, the workers will no stop. It would be useful to be able to stop the whole workload.

## Changes

* Add a shutdown hook to call the /stop-all endpoint on all workers