### PR TITLE
Remove Kafka reset option

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/LocalWorker.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/LocalWorker.java
@@ -159,7 +159,7 @@ public class LocalWorker implements Worker, ConsumerCallback {
     }
 
     private String generateTopicName(int i) {
-        return String.format("%s-%s-%07d", benchmarkDriver.getTopicNamePrefix(), RandomGenerator.getRandomString(), i);
+        return String.format("%s-%07d-%s", benchmarkDriver.getTopicNamePrefix(), i, RandomGenerator.getRandomString());
     }
 
     @Override

--- a/driver-kafka/deploy/ssd-deployment/provision-kafka-aws.tf
+++ b/driver-kafka/deploy/ssd-deployment/provision-kafka-aws.tf
@@ -146,6 +146,10 @@ resource "aws_instance" "client" {
   }
 }
 
+output "kafka_ssh_host" {
+  value = "${aws_instance.kafka.0.public_ip}"
+}
+
 output "client_ssh_host" {
   value = "${aws_instance.client.0.public_ip}"
 }

--- a/driver-kafka/kafka-big-batches-gzip.yaml
+++ b/driver-kafka/kafka-big-batches-gzip.yaml
@@ -18,7 +18,6 @@ driverClass: io.openmessaging.benchmark.driver.kafka.KafkaBenchmarkDriver
 
 # Kafka client-specific configuration
 replicationFactor: 3
-reset: true
 
 topicConfig: |
   min.insync.replicas=2

--- a/driver-kafka/kafka-big-batches-lz4.yaml
+++ b/driver-kafka/kafka-big-batches-lz4.yaml
@@ -18,7 +18,6 @@ driverClass: io.openmessaging.benchmark.driver.kafka.KafkaBenchmarkDriver
 
 # Kafka client-specific configuration
 replicationFactor: 3
-reset: true
 
 topicConfig: |
   min.insync.replicas=2

--- a/driver-kafka/kafka-big-batches-snappy.yaml
+++ b/driver-kafka/kafka-big-batches-snappy.yaml
@@ -18,7 +18,6 @@ driverClass: io.openmessaging.benchmark.driver.kafka.KafkaBenchmarkDriver
 
 # Kafka client-specific configuration
 replicationFactor: 3
-reset: true
 
 topicConfig: |
   min.insync.replicas=2

--- a/driver-kafka/kafka-big-batches-zstd.yaml
+++ b/driver-kafka/kafka-big-batches-zstd.yaml
@@ -18,7 +18,6 @@ driverClass: io.openmessaging.benchmark.driver.kafka.KafkaBenchmarkDriver
 
 # Kafka client-specific configuration
 replicationFactor: 3
-reset: true
 
 topicConfig: |
   min.insync.replicas=2

--- a/driver-kafka/kafka-big-batches.yaml
+++ b/driver-kafka/kafka-big-batches.yaml
@@ -18,7 +18,6 @@ driverClass: io.openmessaging.benchmark.driver.kafka.KafkaBenchmarkDriver
 
 # Kafka client-specific configuration
 replicationFactor: 3
-reset: true
 
 topicConfig: |
   min.insync.replicas=2

--- a/driver-kafka/kafka-compression-gzip.yaml
+++ b/driver-kafka/kafka-compression-gzip.yaml
@@ -18,7 +18,6 @@ driverClass: io.openmessaging.benchmark.driver.kafka.KafkaBenchmarkDriver
 
 # Kafka client-specific configuration
 replicationFactor: 3
-reset: true
 
 topicConfig: |
   min.insync.replicas=2

--- a/driver-kafka/kafka-compression-lz4.yaml
+++ b/driver-kafka/kafka-compression-lz4.yaml
@@ -18,7 +18,6 @@ driverClass: io.openmessaging.benchmark.driver.kafka.KafkaBenchmarkDriver
 
 # Kafka client-specific configuration
 replicationFactor: 3
-reset: true
 
 topicConfig: |
   min.insync.replicas=2

--- a/driver-kafka/kafka-compression-snappy.yaml
+++ b/driver-kafka/kafka-compression-snappy.yaml
@@ -18,7 +18,6 @@ driverClass: io.openmessaging.benchmark.driver.kafka.KafkaBenchmarkDriver
 
 # Kafka client-specific configuration
 replicationFactor: 3
-reset: true
 
 topicConfig: |
   min.insync.replicas=2

--- a/driver-kafka/kafka-compression-zstd.yaml
+++ b/driver-kafka/kafka-compression-zstd.yaml
@@ -18,7 +18,6 @@ driverClass: io.openmessaging.benchmark.driver.kafka.KafkaBenchmarkDriver
 
 # Kafka client-specific configuration
 replicationFactor: 3
-reset: true
 
 topicConfig: |
   min.insync.replicas=2

--- a/driver-kafka/kafka-exactly-once.yaml
+++ b/driver-kafka/kafka-exactly-once.yaml
@@ -18,7 +18,6 @@ driverClass: io.openmessaging.benchmark.driver.kafka.KafkaBenchmarkDriver
 
 # Kafka client-specific configuration
 replicationFactor: 3
-reset: true
 
 topicConfig: |
   min.insync.replicas=2

--- a/driver-kafka/kafka-latency.yaml
+++ b/driver-kafka/kafka-latency.yaml
@@ -18,7 +18,6 @@ driverClass: io.openmessaging.benchmark.driver.kafka.KafkaBenchmarkDriver
 
 # Kafka client-specific configuration
 replicationFactor: 3
-reset: true
 
 topicConfig: |
   min.insync.replicas=2

--- a/driver-kafka/kafka-no-linger.yaml
+++ b/driver-kafka/kafka-no-linger.yaml
@@ -18,7 +18,6 @@ driverClass: io.openmessaging.benchmark.driver.kafka.KafkaBenchmarkDriver
 
 # Kafka client-specific configuration
 replicationFactor: 3
-reset: true
 
 topicConfig: |
   min.insync.replicas=2

--- a/driver-kafka/kafka-sync.yaml
+++ b/driver-kafka/kafka-sync.yaml
@@ -19,7 +19,6 @@ driverClass: io.openmessaging.benchmark.driver.kafka.KafkaBenchmarkDriver
 
 # Kafka client-specific configuration
 replicationFactor: 3
-reset: true
 
 topicConfig: |
   min.insync.replicas=2

--- a/driver-kafka/kafka-throughput.yaml
+++ b/driver-kafka/kafka-throughput.yaml
@@ -18,7 +18,6 @@ driverClass: io.openmessaging.benchmark.driver.kafka.KafkaBenchmarkDriver
 
 # Kafka client-specific configuration
 replicationFactor: 3
-reset: true
 
 topicConfig: |
   min.insync.replicas=2

--- a/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/Config.java
+++ b/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/Config.java
@@ -23,6 +23,4 @@ public class Config {
     public String producerConfig;
 
     public String consumerConfig;
-
-    public boolean reset;
 }

--- a/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/KafkaBenchmarkDriver.java
+++ b/driver-kafka/src/main/java/io/openmessaging/benchmark/driver/kafka/KafkaBenchmarkDriver.java
@@ -23,14 +23,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.DeleteTopicsResult;
-import org.apache.kafka.clients.admin.ListTopicsResult;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -85,20 +81,6 @@ public class KafkaBenchmarkDriver implements BenchmarkDriver {
         topicProperties.load(new StringReader(config.topicConfig));
 
         admin = AdminClient.create(commonProperties);
-
-        if (config.reset) {
-            // List existing topics
-            ListTopicsResult result = admin.listTopics();
-            try {
-                Set<String> topics = result.names().get();
-                // Delete all existing topics
-                DeleteTopicsResult deletes = admin.deleteTopics(topics);
-                deletes.all().get();
-            } catch (InterruptedException | ExecutionException e) {
-                e.printStackTrace();
-                throw new IOException(e);
-            }
-        }
     }
 
     @Override


### PR DESCRIPTION
## Motivation

The Kafka driver has the ability to `reset` on initialisation which will delete all topics. All workers will attempt to perform this action which can result in contention for resources and UnknownTopicOrPartitionException. This can make it hard to execute workloads, particularly those with lots of topics.

## Changes

* Remove the Kafka `reset` option
* Expose the Kafka ssh IP address in the terraform to make it easier for users to ssh in to a broker and manually delete topics if needed with the following command `/opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --delete --topic test-topic-.*`
* Reorder the Kafka topic names to make selection deletion easier