### PR TITLE
Add backlog drain timings to the log

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
@@ -358,7 +358,7 @@ public class WorkloadGenerator implements AutoCloseable {
             }
         }
 
-        log.info("--- Completed backlog build in {} ms ---", timer.elapsedMillis());
+        log.info("--- Completed backlog build in {} s ---", timer.elapsedSeconds());
         timer = new Timer();
         log.info("--- Start draining backlog ---");
 
@@ -370,7 +370,7 @@ public class WorkloadGenerator implements AutoCloseable {
             CountersStats stats = worker.getCountersStats();
             long currentBacklog = workload.subscriptionsPerTopic * stats.messagesSent - stats.messagesReceived;
             if (currentBacklog <= minBacklog) {
-                log.info("--- Completed backlog draining in {} ms ---", timer.elapsedMillis());
+                log.info("--- Completed backlog draining in {} s ---", timer.elapsedSeconds());
                 needToWaitForBacklogDraining = false;
                 return;
             }

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
@@ -334,6 +334,7 @@ public class WorkloadGenerator implements AutoCloseable {
     }
 
     private void buildAndDrainBacklog(List<String> topics) throws IOException {
+        Timer timer = new Timer();
         log.info("Stopping all consumers to build backlog");
         worker.pauseConsumers();
 
@@ -357,6 +358,8 @@ public class WorkloadGenerator implements AutoCloseable {
             }
         }
 
+        log.info("--- Completed backlog build in {} ms ---", timer.elapsedMillis());
+        timer = new Timer();
         log.info("--- Start draining backlog ---");
 
         worker.resumeConsumers();
@@ -367,7 +370,7 @@ public class WorkloadGenerator implements AutoCloseable {
             CountersStats stats = worker.getCountersStats();
             long currentBacklog = workload.subscriptionsPerTopic * stats.messagesSent - stats.messagesReceived;
             if (currentBacklog <= minBacklog) {
-                log.info("--- Completed backlog draining ---");
+                log.info("--- Completed backlog draining in {} ms ---", timer.elapsedMillis());
                 needToWaitForBacklogDraining = false;
                 return;
             }

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/Timer.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/Timer.java
@@ -23,7 +23,15 @@ public class Timer {
     }
 
     public double elapsedMillis() {
+        return elapsed(TimeUnit.MILLISECONDS);
+    }
+
+    public double elapsedSeconds() {
+        return elapsed(TimeUnit.SECONDS);
+    }
+
+    private double elapsed(TimeUnit unit) {
         long now = System.nanoTime();
-        return (now - startTime) / (double) TimeUnit.MILLISECONDS.toNanos(1);
+        return (now - startTime) / (double) unit.toNanos(1);
     }
 }


### PR DESCRIPTION
## Motivation

It can take time to determine how to scale up backlog drain workloads. How long it takes to build the backlog and drain it are useful pieces of information.

## Changes

* Add timers to the log of the backlog build up time and backlog drain time