### PR TITLE
Move shutdown hook

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Benchmark.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Benchmark.java
@@ -14,7 +14,6 @@
 package io.openmessaging.benchmark;
 
 import java.io.File;
-import java.io.IOException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -128,7 +127,6 @@ public class Benchmark {
 
         if (arguments.workers != null && !arguments.workers.isEmpty()) {
             worker = new DistributedWorkersEnsemble(arguments.workers, arguments.extraConsumers);
-            Runtime.getRuntime().addShutdownHook(new Thread(worker::stopAll));
         } else {
             // Use local worker implementation
             worker = new LocalWorker();

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/DistributedWorkersEnsemble.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/DistributedWorkersEnsemble.java
@@ -54,7 +54,7 @@ import io.openmessaging.benchmark.worker.commands.TopicSubscription;
 import io.openmessaging.benchmark.worker.commands.TopicsInfo;
 
 public class DistributedWorkersEnsemble implements Worker {
-
+    private final Thread shutdownHook = new Thread(this::stopAll);
     private final List<String> workers;
     private final List<String> producerWorkers;
     private final List<String> consumerWorkers;
@@ -80,6 +80,8 @@ public class DistributedWorkersEnsemble implements Worker {
 
         log.info("Workers list - producers: {}", producerWorkers);
         log.info("Workers list - consumers: {}", consumerWorkers);
+
+        Runtime.getRuntime().addShutdownHook(shutdownHook);
     }
 
     @Override
@@ -331,6 +333,7 @@ public class DistributedWorkersEnsemble implements Worker {
 
     @Override
     public void close() throws Exception {
+        Runtime.getRuntime().removeShutdownHook(shutdownHook);
         httpClient.close();
     }
 


### PR DESCRIPTION
## Motivation

On normal completion, the shutdown hook still executes, but after the http client has been close resulting in exceptions in the log

## Changes

* Move the shutdown hook into DistributedWorkersEnsemble
* Remove the shutdown hook on close, before the http client is closed.