### PR TITLE
Cleanup logging

### DIFF
--- a/benchmark-framework/pom.xml
+++ b/benchmark-framework/pom.xml
@@ -114,6 +114,10 @@
 			<version>${bookkeeper.version}</version>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j-impl</artifactId>
+		</dependency>
+		<dependency>
             <groupId>io.javalin</groupId>
             <artifactId>javalin</artifactId>
             <version>1.3.0</version>

--- a/driver-api/pom.xml
+++ b/driver-api/pom.xml
@@ -50,9 +50,5 @@
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-simple</artifactId>
-		</dependency>
 	</dependencies>
 </project>

--- a/driver-kafka/pom.xml
+++ b/driver-kafka/pom.xml
@@ -43,6 +43,11 @@
 			<artifactId>assertj-core</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-slf4j-impl</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter</artifactId>
 			<version>5.9.0</version>

--- a/driver-kafka/src/test/resources/log4j2.yaml
+++ b/driver-kafka/src/test/resources/log4j2.yaml
@@ -12,7 +12,22 @@
 # limitations under the License.
 #
 
-org.slf4j.simpleLogger.showDateTime=true
-org.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss.SSS
-org.slf4j.simpleLogger.log.org.apache.kafka=WARN
-org.slf4j.simpleLogger.log.io.openmessaging.benchmark.driver.kafka=DEBUG
+Configuration:
+  status: INFO
+  name: driver-kafka-test
+  
+  Appenders:
+    Console:
+      name: Console
+      target: SYSTEM_OUT
+      PatternLayout:
+        Pattern: "%d{HH:mm:ss.SSS} [%t] %-4level %c{1} - %msg%n"
+  Loggers:
+    Logger:
+      name: io.openmessaging.benchmark.driver.kafka
+      level: debug
+    Root:
+      level: info
+      additivity: false
+      AppenderRef:
+        - ref: Console

--- a/driver-kop/src/test/java/io/openmessaging/benchmark/driver/kop/KopBenchmarkDriverTest.java
+++ b/driver-kop/src/test/java/io/openmessaging/benchmark/driver/kop/KopBenchmarkDriverTest.java
@@ -74,7 +74,7 @@ public class KopBenchmarkDriverTest {
         assertFalse(pulsarConfig.blockIfQueueFull);
         assertEquals(pulsarConfig.pendingQueueSize, 10000);
         assertEquals(pulsarConfig.maxPendingMessagesAcrossPartitions, 500000);
-        assertEquals(pulsarConfig.batchingPartitionSwitchFrequencyByPublishDelay, 100);
+        assertEquals(pulsarConfig.batchingPartitionSwitchFrequencyByPublishDelay, 10);
         assertEquals(pulsarConfig.maxTotalReceiverQueueSizeAcrossPartitions, 500000);
         assertEquals(pulsarConfig.receiverQueueSize, 10000);
 

--- a/pom.xml
+++ b/pom.xml
@@ -180,11 +180,6 @@
 				<version>${lombok.version}</version>
 				<scope>provided</scope>
 			</dependency>
-			<dependency>
-				<groupId>org.slf4j</groupId>
-				<artifactId>slf4j-simple</artifactId>
-				<version>${slf4j.version}</version>
-			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/tool/pom.xml
+++ b/tool/pom.xml
@@ -41,8 +41,8 @@
       <artifactId>jcommander</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/tool/src/main/resources/log4j2.yaml
+++ b/tool/src/main/resources/log4j2.yaml
@@ -14,7 +14,7 @@
 
 Configuration:
   status: INFO
-  name: messaging-benchmark
+  name: driver-kafka-test
   
   Appenders:
     Console:
@@ -22,21 +22,9 @@ Configuration:
       target: SYSTEM_OUT
       PatternLayout:
         Pattern: "%d{HH:mm:ss.SSS} [%t] %-4level %c{1} - %msg%n"
-    RollingFile:
-      name: RollingFile
-      fileName: benchmark-worker.log
-      filePattern: benchmark-worker.log.%d{yyyy-MM-dd-hh-mm-ss}.gz
-      PatternLayout:
-        Pattern: "%d{HH:mm:ss.SSS} [%t] %-4level %c{1} - %msg%n"
-      Policies:
-        SizeBasedTriggeringPolicy:
-          size: 100MB
-      DefaultRollOverStrategy:
-        max: 10
-  Loggers: 
+  Loggers:
     Root:
       level: info
       additivity: false
       AppenderRef:
         - ref: Console
-        - ref: RollingFile


### PR DESCRIPTION
## Motivation

log4j-slf4j-simpl and slf4j-simple are both on the classpath in various places which is messing up the logging.

## Changes

* Replace slf4j-simple with log4j-slf4j-impl