### PR TITLE
[Clean-up] Remove unused JUnit 4

### DIFF
--- a/benchmark-framework/pom.xml
+++ b/benchmark-framework/pom.xml
@@ -134,10 +134,6 @@
 			<artifactId>jetty-util</artifactId>
 			<version>${jetty.version}</version>
 		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-		</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,6 @@
 		<lombok.version>1.18.24</lombok.version>
 		<jackson.version>2.13.2</jackson.version>
 		<jcommander.version>1.48</jcommander.version>
-		<junit.version>4.13.1</junit.version>
 		<netty.version>4.1.65.Final</netty.version>
 		<slf4j.version>1.7.36</slf4j.version>
 	</properties>
@@ -146,12 +145,6 @@
 				<groupId>io.netty</groupId>
 				<artifactId>netty-all</artifactId>
 				<version>${netty.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>junit</groupId>
-				<artifactId>junit</artifactId>
-				<version>${junit.version}</version>
-				<scope>test</scope>
 			</dependency>
 			<dependency>
 				<groupId>org.assertj</groupId>


### PR DESCRIPTION
# Motivations

Keep project dependencies tidy.

# Changes

Remove unused JUnit4 dependency, especially as we already have JUnit5 and TestNG in the project.