### PR TITLE
[RabbitMQ] Clean-up deploy

### DIFF
--- a/driver-rabbitmq/deploy/deploy.yaml
+++ b/driver-rabbitmq/deploy/deploy.yaml
@@ -90,6 +90,7 @@
       state: restarted
       daemon_reload: yes
       name: "rabbitmq-server"
+    tags: [restart-rabbitmq]
 
   - name: RabbitMQ status
     shell: rabbitmqctl cluster_status
@@ -162,36 +163,44 @@
       unarchive:
         src: ../../package/target/openmessaging-benchmark-0.0.1-SNAPSHOT-bin.tar.gz
         dest: /opt
+      tags: [client-code]
     - shell: >
         tuned-adm profile latency-performance &&
         mv /opt/openmessaging-benchmark-0.0.1-SNAPSHOT /opt/benchmark
+      tags: [client-code]
 
     - template:
         src: "templates/workers.yaml"
         dest: "/opt/benchmark/workers.yaml"
+      tags: [client-code]
 
     - template:
         src: "templates/rabbitmq.yaml"
         dest: "/opt/benchmark/driver-rabbitmq/rabbitmq.yaml"
+      tags: [client-code]
 
     - name: Configure benchmark-worker memory
       lineinfile:
         dest: /opt/benchmark/bin/benchmark-worker
         regexp: '^JVM_MEM='
         line: 'JVM_MEM="-Xms100G -Xmx100G -XX:+UnlockExperimentalVMOptions -XX:+UseZGC -XX:+ParallelRefProcEnabled -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=12 -XX:ConcGCThreads=12 -XX:+DisableExplicitGC -XX:-ResizePLAB"'
+      tags: [client-code]
     - name: Configure benchmark memory
       lineinfile:
         dest: /opt/benchmark/bin/benchmark
         regexp: '^JVM_MEM='
         line: 'JVM_MEM="-Xmx4G"'
+      tags: [client-code]
     - name: Install benchmark-worker systemd service
       template:
         src: "templates/benchmark-worker.service"
         dest: "/etc/systemd/system/benchmark-worker.service"
+      tags: [client-code]
     - systemd:
         state: restarted
         daemon_reload: yes
         name: "benchmark-worker"
+      tags: [client-code]
 
 - name: List host addresses
   hosts: localhost

--- a/driver-rabbitmq/deploy/deploy.yaml
+++ b/driver-rabbitmq/deploy/deploy.yaml
@@ -146,7 +146,7 @@
         daemon_reload: yes
         name: "chronyd"
 
-- name: Rabbitmq benchmarking client setup
+- name: RabbitMQ benchmarking client setup
   hosts: client
   connection: ssh
   become: true

--- a/driver-rabbitmq/deploy/deploy.yaml
+++ b/driver-rabbitmq/deploy/deploy.yaml
@@ -164,10 +164,9 @@
         src: ../../package/target/openmessaging-benchmark-0.0.1-SNAPSHOT-bin.tar.gz
         dest: /opt
       tags: [client-code]
-    - shell: >
-        tuned-adm profile latency-performance &&
-        mv /opt/openmessaging-benchmark-0.0.1-SNAPSHOT /opt/benchmark
+    - shell: mv /opt/openmessaging-benchmark-0.0.1-SNAPSHOT /opt/benchmark
       tags: [client-code]
+    - shell: tuned-adm profile latency-performance
 
     - template:
         src: "templates/workers.yaml"

--- a/driver-rabbitmq/deploy/provision-rabbitmq-aws.tf
+++ b/driver-rabbitmq/deploy/provision-rabbitmq-aws.tf
@@ -105,7 +105,7 @@ resource "aws_instance" "rabbitmq" {
   count                  = "${var.num_instances["rabbitmq"]}"
 
   tags = {
-    Name = "rabbitmq-${count.index}"
+    Name = "rabbitmq_${count.index}"
   }
 }
 
@@ -118,7 +118,7 @@ resource "aws_instance" "client" {
   count                  = "${var.num_instances["client"]}"
 
   tags = {
-    Name = "rabbitmq-client-${count.index}"
+    Name = "rabbitmq_client_${count.index}"
   }
 }
 


### PR DESCRIPTION
# Motivation
It can be useful to simple restart RMQ instances, or to redeploy the client code only.

# Changes

* Tag tasks for targeted `client-code` deployment, and `restart-rabbitmq` only
* Remove Ansible warning by swapping`-` for `_` in Terraform inventory names