### PR TITLE
[Feature] Collect producer error stats

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Benchmark.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Benchmark.java
@@ -156,8 +156,10 @@ public class Benchmark {
                     String fileName = useOutput? arguments.output: String.format("%s-%s-%s.json", workloadName,
                     driverConfiguration.name, dateFormat.format(new Date()));
 
-                    log.info("Writing test result into {}", fileName);
-                    writer.writeValue(new File(fileName), result);
+                    log.info("Writing test result into {}/{}", workloadName, fileName);
+                    File folder = new File(workloadName);
+                    folder.mkdirs();
+                    writer.writeValue(new File(folder, fileName), result);
 
                     generator.close();
                 } catch (Exception e) {

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Benchmark.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Benchmark.java
@@ -158,7 +158,9 @@ public class Benchmark {
 
                     log.info("Writing test result into {}/{}", workloadName, fileName);
                     File folder = new File(workloadName);
-                    folder.mkdirs();
+                    if (!folder.mkdirs()) {
+                        log.debug("Unable to create folder {}", folder);
+                    }
                     writer.writeValue(new File(folder, fileName), result);
 
                     generator.close();

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/TestResult.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/TestResult.java
@@ -28,6 +28,7 @@ public class TestResult {
     public int consumersPerTopic;
 
     public List<Double> publishRate = new ArrayList<>();
+    public List<Double> publishErrorRate = new ArrayList<>();
     public List<Double> consumeRate = new ArrayList<>();
     public List<Long> backlog = new ArrayList<>();
 

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
@@ -440,6 +440,7 @@ public class WorkloadGenerator implements AutoCloseable {
                     throughputFormat.format(stats.publishDelayLatency.getMaxValue()));
 
             result.publishRate.add(publishRate);
+            result.publishErrorRate.add(errorRate);
             result.consumeRate.add(consumeRate);
             result.backlog.add(currentBacklog);
             result.publishLatencyAvg.add(microsToMillis(stats.publishLatency.getMean()));

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
@@ -414,6 +414,7 @@ public class WorkloadGenerator implements AutoCloseable {
 
             double publishRate = stats.messagesSent / elapsed;
             double publishThroughput = stats.bytesSent / elapsed / 1024 / 1024;
+            double errorRate = stats.messageSendErrors / elapsed;
 
             double consumeRate = stats.messagesReceived / elapsed;
             double consumeThroughput = stats.bytesReceived / elapsed / 1024 / 1024;
@@ -422,8 +423,9 @@ public class WorkloadGenerator implements AutoCloseable {
                     - stats.totalMessagesReceived;
 
             log.info(
-                    "Pub rate {} msg/s / {} MB/s | Cons rate {} msg/s / {} MB/s | Backlog: {} K | Pub Latency (ms) avg: {} - 50%: {} - 99%: {} - 99.9%: {} - Max: {} | Pub Delay Latency (us) avg: {} - 50%: {} - 99%: {} - 99.9%: {} - Max: {}",
+                    "Pub rate {} msg/s / {} MB/s | Pub err {} err/s | Cons rate {} msg/s / {} MB/s | Backlog: {} K | Pub Latency (ms) avg: {} - 50%: {} - 99%: {} - 99.9%: {} - Max: {} | Pub Delay Latency (us) avg: {} - 50%: {} - 99%: {} - 99.9%: {} - Max: {}",
                     rateFormat.format(publishRate), throughputFormat.format(publishThroughput),
+                    rateFormat.format(errorRate),
                     rateFormat.format(consumeRate), throughputFormat.format(consumeThroughput),
                     dec.format(currentBacklog / 1000.0), //
                     dec.format(microsToMillis(stats.publishLatency.getMean())),

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
@@ -419,8 +419,8 @@ public class WorkloadGenerator implements AutoCloseable {
             double consumeRate = stats.messagesReceived / elapsed;
             double consumeThroughput = stats.bytesReceived / elapsed / 1024 / 1024;
 
-            long currentBacklog = workload.subscriptionsPerTopic * stats.totalMessagesSent
-                    - stats.totalMessagesReceived;
+            long currentBacklog = Math.max(0L, workload.subscriptionsPerTopic * stats.totalMessagesSent
+                    - stats.totalMessagesReceived);
 
             log.info(
                     "Pub rate {} msg/s / {} MB/s | Pub err {} err/s | Cons rate {} msg/s / {} MB/s | Backlog: {} K | Pub Latency (ms) avg: {} - 50%: {} - 99%: {} - 99.9%: {} - Max: {} | Pub Delay Latency (us) avg: {} - 50%: {} - 99%: {} - 99.9%: {} - Max: {}",

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/DistributedWorkersEnsemble.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/DistributedWorkersEnsemble.java
@@ -193,10 +193,12 @@ public class DistributedWorkersEnsemble implements Worker {
         PeriodStats stats = new PeriodStats();
         individualStats.forEach(is -> {
             stats.messagesSent += is.messagesSent;
+            stats.messageSendErrors += is.messageSendErrors;
             stats.bytesSent += is.bytesSent;
             stats.messagesReceived += is.messagesReceived;
             stats.bytesReceived += is.bytesReceived;
             stats.totalMessagesSent += is.totalMessagesSent;
+            stats.totalMessageSendErrors += is.totalMessageSendErrors;
             stats.totalMessagesReceived += is.totalMessagesReceived;
 
             try {
@@ -262,6 +264,7 @@ public class DistributedWorkersEnsemble implements Worker {
         individualStats.forEach(is -> {
             stats.messagesSent += is.messagesSent;
             stats.messagesReceived += is.messagesReceived;
+            stats.messageSendErrors += is.messageSendErrors;
         });
 
         return stats;

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/commands/CountersStats.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/commands/CountersStats.java
@@ -16,4 +16,5 @@ package io.openmessaging.benchmark.worker.commands;
 public class CountersStats {
     public long messagesSent;
     public long messagesReceived;
+    public long messageSendErrors;
 }

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/commands/PeriodStats.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/commands/PeriodStats.java
@@ -21,12 +21,14 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 
 public class PeriodStats {
     public long messagesSent = 0;
+    public long messageSendErrors = 0;
     public long bytesSent = 0;
 
     public long messagesReceived = 0;
     public long bytesReceived = 0;
 
     public long totalMessagesSent = 0;
+    public long totalMessageSendErrors = 0;
     public long totalMessagesReceived = 0;
 
     @JsonIgnore

--- a/bin/create_charts.py
+++ b/bin/create_charts.py
@@ -46,6 +46,10 @@ def create_charts(test_results):
                      y_label='Rate (msg/s)',
                      time_series=[(x['driver'], x['publishRate']) for x in results])
 
+        create_chart(workload, 'Publish Error rate',
+                     y_label='Rate (err/s)',
+                     time_series=[(x['driver'], x['publishErrorRate']) for x in results])
+
         create_chart(workload, 'End To End Latency 95pct',
                      y_label='Latency (ms)',
                      time_series=[(x['driver'], x['endToEndLatency95pct']) for x in results])


### PR DESCRIPTION
# Motivation
When a system is at the limits of its performance envelope, it may more readily fall into erroneous states and behaviour quite differently — an open circuit breaker may have a very low latency compared to a message send. Therefore it is desirable to have metrics on producer errors so these conditions can be observed.

# Changes
* Added `messageSendErrors` counters and accumulators
* Added capture of publish errors
* Updated metrics pathways to include send errors
* Updated loggers, file writers to include send errors
* Charger rendering also outputs error graph