### PR TITLE
Fix spotless with markdown

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,6 @@
 							<includes>
 								<include>etc/**/*.xml</include>
 								<include>.github/workflows/**/*.yml</include>
-								<include>**/doc/**/*.md</include>
 								<include>**/doc/**/*.puml</include>
 							</includes>
 							<trimTrailingWhitespace/>


### PR DESCRIPTION
Partially addresses #313

## Motivation

The current spotless configuration is applies twice with slightly differing results so a `spotless:apply` then fails a `spotless:check`

## Changes

* Remove md files from the general formats so that only markdown flexmark is applied