### PR TITLE
Allow spaces in empty for iterator

### DIFF
--- a/etc/checkstyle.xml
+++ b/etc/checkstyle.xml
@@ -151,7 +151,9 @@
 
     <!-- Checks for whitespace                               -->
     <!-- See https://checkstyle.org/config_whitespace.html -->
-    <module name="EmptyForIteratorPad"/>
+    <module name="EmptyForIteratorPad">
+      <property name="option" value="space"/>
+    </module>
     <module name="GenericWhitespace"/>
     <module name="MethodParamPad"/>
     <module name="NoWhitespaceAfter"/>


### PR DESCRIPTION
Partially addresses #313

## Motivation

spotless (googleJavaFormat) expects whitespace in an empty for iterator, but checkstyle does not.

## Changes

* Update checkstyle configuration to allow whitespace