### PR TITLE
[RabbitMQ] Expose management port

### DIFF
--- a/driver-rabbitmq/README.md
+++ b/driver-rabbitmq/README.md
@@ -112,3 +112,12 @@ You can also run specific workloads in the `workloads` folder. Here's an example
 ```bash
 $ sudo bin/benchmark --drivers driver-rabbotmq/rabbitmq.yaml workloads/1-topic-1-partitions-1kb.yaml
 ```
+
+## Monitoring
+
+The `rabbitmq_management` plugin is installed, and the HTTP endpoint is exposed on all RabbitMQ instances on port
+`15672`. This allows access to the management UI which provides some basic status metrics. It should also be possible
+to access the management REST API at this endpoint.
+
+Note that the connection is authenticated but not currently encrypted and so passwords will be passed in plain text. Use
+the `admin` account configured in the [Terraform](deploy/provision-rabbitmq-aws.tf) file to log in. 

--- a/driver-rabbitmq/deploy/provision-rabbitmq-aws.tf
+++ b/driver-rabbitmq/deploy/provision-rabbitmq-aws.tf
@@ -70,6 +70,14 @@ resource "aws_security_group" "benchmark_security_group" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  # Management UI access from anywhere
+  ingress {
+    from_port   = 15672
+    to_port     = 15672
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   # All ports open within the VPC
   ingress {
     from_port   = 0


### PR DESCRIPTION
# Motivation
To observe how the RabbitMQ instances are performing during the benchmark and identify bottlenecks in RMQ.

# Changes
* Expose management interface publicly (**NOT SECURE**)
* Update README to describe how to access management UI