### PR TITLE
[RabbitMQ] Use quorum queues

### DIFF
--- a/driver-rabbitmq/src/main/java/io/openmessaging/benchmark/driver/rabbitmq/RabbitMqBenchmarkDriver.java
+++ b/driver-rabbitmq/src/main/java/io/openmessaging/benchmark/driver/rabbitmq/RabbitMqBenchmarkDriver.java
@@ -123,7 +123,7 @@ public class RabbitMqBenchmarkDriver implements BenchmarkDriver {
                 String queueName = exchange + "-" + subscriptionName;
                 channel.exchangeDeclare(exchange, BuiltinExchangeType.FANOUT, true);
                 // Create the queue
-                channel.queueDeclare(queueName, true, false, false, Collections.emptyMap());
+                channel.queueDeclare(queueName, true, false, false, Collections.singletonMap("x-queue-type", "quorum"));
                 channel.queueBind(queueName, exchange, "");
                 future.complete(new RabbitMqBenchmarkConsumer(channel, queueName, consumerCallback));
             } catch (IOException e) {


### PR DESCRIPTION
# Motivation
To before fair benchmarking using current RMQ primitives. Classic replicated queues have been deprecated, replaced by quorum queues and streams.

# Changes
* Creates quorum queues instead of classic queues 