### PR TITLE
New max sustainable rate implementation

### DIFF
--- a/benchmark-framework/pom.xml
+++ b/benchmark-framework/pom.xml
@@ -119,10 +119,6 @@
             <artifactId>log4j-slf4j-impl</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.asynchttpclient</groupId>
             <artifactId>async-http-client</artifactId>
             <version>2.12.3</version>
@@ -144,12 +140,30 @@
             <version>2.1.12</version>
         </dependency>
         <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-lambda</artifactId>
+            <version>1.2.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/RateController.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/RateController.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openmessaging.benchmark;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static lombok.AccessLevel.PACKAGE;
+
+import io.openmessaging.benchmark.utils.Env;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+class RateController {
+    private static final long ONE_SECOND_IN_NANOS = SECONDS.toNanos(1);
+    private final long publishBacklogLimit;
+    private final long receiveBacklogLimit;
+    private final double minRampingFactor;
+    private final double maxRampingFactor;
+
+    @Getter(PACKAGE)
+    private double rampingFactor;
+
+    private long previousTotalPublished = 0;
+    private long previousTotalReceived = 0;
+
+    RateController() {
+        publishBacklogLimit = Env.getLong("PUBLISH_BACKLOG_LIMIT", 1_000);
+        receiveBacklogLimit = Env.getLong("RECEIVE_BACKLOG_LIMIT", 1_000);
+        minRampingFactor = Env.getDouble("MIN_RAMPING_FACTOR", 0.01);
+        maxRampingFactor = Env.getDouble("MAX_RAMPING_FACTOR", 1);
+        rampingFactor = maxRampingFactor;
+    }
+
+    double nextRate(double rate, long periodNanos, long totalPublished, long totalReceived) {
+        long expected = (long) ((rate / ONE_SECOND_IN_NANOS) * periodNanos);
+        long published = totalPublished - previousTotalPublished;
+        long received = totalReceived - previousTotalReceived;
+
+        previousTotalPublished = totalPublished;
+        previousTotalReceived = totalReceived;
+
+        if (log.isDebugEnabled()) {
+            log.debug(
+                    "Current rate: {} -- Publish rate {} -- Receive Rate: {}",
+                    rate,
+                    rate(published, periodNanos),
+                    rate(received, periodNanos));
+        }
+
+        long receiveBacklog = totalPublished - totalReceived;
+        if (receiveBacklog > receiveBacklogLimit) {
+            return nextRate(periodNanos, received, expected, receiveBacklog, "Receive");
+        }
+
+        long publishBacklog = expected - published;
+        if (publishBacklog > publishBacklogLimit) {
+            return nextRate(periodNanos, published, expected, publishBacklog, "Publish");
+        }
+
+        rampUp();
+
+        return rate + (rate * rampingFactor);
+    }
+
+    private double nextRate(long periodNanos, long actual, long expected, long backlog, String type) {
+        log.debug("{} backlog: {}", type, backlog);
+        rampDown();
+        long nextExpected = Math.max(0, expected - backlog);
+        double nextExpectedRate = rate(nextExpected, periodNanos);
+        double actualRate = rate(actual, periodNanos);
+        return Math.min(actualRate, nextExpectedRate);
+    }
+
+    private double rate(long count, long periodNanos) {
+        return (count / (double) periodNanos) * ONE_SECOND_IN_NANOS;
+    }
+
+    private void rampUp() {
+        rampingFactor = Math.min(maxRampingFactor, rampingFactor * 2);
+    }
+
+    private void rampDown() {
+        rampingFactor = Math.max(minRampingFactor, rampingFactor / 2);
+    }
+}

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/Env.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/Env.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openmessaging.benchmark.utils;
+
+
+import java.util.Optional;
+import java.util.function.Function;
+
+public final class Env {
+    private Env() {}
+
+    public static long getLong(String key, long defaultValue) {
+        return get(key, Long::parseLong, defaultValue);
+    }
+
+    public static double getDouble(String key, double defaultValue) {
+        return get(key, Double::parseDouble, defaultValue);
+    }
+
+    public static <T> T get(String key, Function<String, T> function, T defaultValue) {
+        return Optional.ofNullable(System.getenv(key)).map(function).orElse(defaultValue);
+    }
+}

--- a/benchmark-framework/src/test/java/io/openmessaging/benchmark/RateControllerTest.java
+++ b/benchmark-framework/src/test/java/io/openmessaging/benchmark/RateControllerTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openmessaging.benchmark;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class RateControllerTest {
+    private final RateController rateController = new RateController();
+    private double rate = 10_000;
+    private long periodNanos = SECONDS.toNanos(1);
+
+    @Test
+    void receiveBacklog() {
+        assertThat(rateController.getRampingFactor()).isEqualTo(1);
+
+        // no backlog
+        rate = rateController.nextRate(rate, periodNanos, 10_000, 10_000);
+        assertThat(rate).isEqualTo(20_000);
+        assertThat(rateController.getRampingFactor()).isEqualTo(1);
+
+        // receive backlog
+        rate = rateController.nextRate(rate, periodNanos, 20_000, 15_000);
+        assertThat(rate).isEqualTo(5_000);
+        assertThat(rateController.getRampingFactor()).isEqualTo(0.5);
+    }
+
+    @Test
+    void publishBacklog() {
+        assertThat(rateController.getRampingFactor()).isEqualTo(1);
+
+        // no backlog
+        rate = rateController.nextRate(rate, periodNanos, 10_000, 10_000);
+        assertThat(rate).isEqualTo(20_000);
+        assertThat(rateController.getRampingFactor()).isEqualTo(1);
+
+        // publish backlog
+        rate = rateController.nextRate(rate, periodNanos, 15_000, 20_000);
+        assertThat(rate).isEqualTo(5_000);
+        assertThat(rateController.getRampingFactor()).isEqualTo(0.5);
+    }
+
+    @Test
+    void rampUp() {
+        assertThat(rateController.getRampingFactor()).isEqualTo(1);
+
+        // receive backlog
+        rate = rateController.nextRate(rate, periodNanos, 10_000, 5_000);
+        assertThat(rate).isEqualTo(5_000);
+        assertThat(rateController.getRampingFactor()).isEqualTo(0.5);
+
+        // no backlog
+        rate = rateController.nextRate(rate, periodNanos, 20_000, 20_000);
+        assertThat(rate).isEqualTo(10_000);
+        assertThat(rateController.getRampingFactor()).isEqualTo(1);
+    }
+}

--- a/benchmark-framework/src/test/java/io/openmessaging/benchmark/utils/EnvTest.java
+++ b/benchmark-framework/src/test/java/io/openmessaging/benchmark/utils/EnvTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openmessaging.benchmark.utils;
+
+import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class EnvTest {
+    private static final String ENV_KEY = "KEY";
+
+    @Test
+    void envLong() throws Exception {
+        withEnvironmentVariable(ENV_KEY, "2")
+                .execute(
+                        () -> {
+                            assertThat(Env.getLong(ENV_KEY, 1)).isEqualTo(2);
+                        });
+    }
+
+    @Test
+    void envLongDefault() throws Exception {
+        withEnvironmentVariable(ENV_KEY, null)
+                .execute(
+                        () -> {
+                            assertThat(Env.getLong(ENV_KEY, 1)).isEqualTo(1);
+                        });
+    }
+
+    @Test
+    void envDouble() throws Exception {
+        withEnvironmentVariable(ENV_KEY, "2.34")
+                .execute(
+                        () -> {
+                            assertThat(Env.getDouble(ENV_KEY, 1.23)).isEqualTo(2.34);
+                        });
+    }
+
+    @Test
+    void envDoubleDefault() throws Exception {
+        withEnvironmentVariable(ENV_KEY, null)
+                .execute(
+                        () -> {
+                            assertThat(Env.getDouble(ENV_KEY, 1.23)).isEqualTo(1.23);
+                        });
+    }
+}

--- a/benchmark-framework/src/test/resources/log4j2.yaml
+++ b/benchmark-framework/src/test/resources/log4j2.yaml
@@ -1,0 +1,33 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+Configuration:
+  status: INFO
+  name: messaging-benchmark
+  
+  Appenders:
+    Console:
+      name: Console
+      target: SYSTEM_OUT
+      PatternLayout:
+        Pattern: "%d{HH:mm:ss.SSS} [%t] %-4level %c{1} - %msg%n"
+  Loggers:
+    Logger:
+      - name: io.openmessaging
+        level: debug
+    Root:
+      level: info
+      additivity: false
+      AppenderRef:
+        - ref: Console

--- a/driver-rocketmq/pom.xml
+++ b/driver-rocketmq/pom.xml
@@ -53,6 +53,12 @@
             <groupId>org.apache.rocketmq</groupId>
             <artifactId>rocketmq-tools</artifactId>
             <version>${rocketmq.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -350,6 +350,10 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven.surefire.plugin.version}</version>
+                <configuration>
+                    <!-- Required by system-lambda test dependency -->
+                    <argLine>--add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+                </configuration>
             </plugin>
             <plugin>
                 <!-- Check test coverage -->


### PR DESCRIPTION
## Motivation

Currently the WorkloadGenerator.findMaximumSustainableRate algorithm introduces publish delay. It has been observed the algorithm settles on a publish rate that neither producers nor consumers can keep up with. For example, on a Kafka workload with 100 topics, 1kb message, the algorithm settled on a publish rate of 2.5m msg/s when the producers could only actually achieve 2m msg/s.

## Changes

Implement a new algorithm that checks for both receive backlog and publish backlog and adjusts the publish according and has a progressive rate ramp up when there is no observed backlog.