### PR TITLE
[RabbitMQ] Prometheus & Grafana

### DIFF
--- a/driver-rabbitmq/README.md
+++ b/driver-rabbitmq/README.md
@@ -126,8 +126,10 @@ the `admin` account configured in the [Terraform](deploy/provision-rabbitmq-aws.
 
 ### Prometheus
 The `rabbitmq_prometheus` plugin is installed and Prometheus is installed on a standalone instance. This exposes a
-public endpoint `http://${prometheus_host}:9090`.
-
-See 
+public endpoint `http://${prometheus_host}:9090`. See
 '[RabbitMQ.com — Monitoring with Prometheus & Grafana](https://www.rabbitmq.com/prometheus.html)' for more information.
+
+### Grafana
+Grafana and [RabbitMQ's standard dashboards](https://grafana.com/rabbitmq) are installed alongside Prometheus. These
+are exposed on a public endpoint `http://${prometheus_host}:3000`. 
 

--- a/driver-rabbitmq/README.md
+++ b/driver-rabbitmq/README.md
@@ -53,10 +53,11 @@ $ terraform apply
 
 That will install the following [EC2](https://aws.amazon.com/ec2) instances (plus some other resources, such as a [Virtual Private Cloud](https://aws.amazon.com/vpc/) (VPC)):
 
-| Resource           | Description                                                 | Count |
-|:-------------------|:------------------------------------------------------------|:------|
-| RabbitMQ instances | The VMs on which RabbitMQ brokers will run                  | 3     |
-| Client instance    | The VM from which the benchmarking suite itself will be run | 1     |
+| Resource            | Description                                                 | Count |
+|:--------------------|:------------------------------------------------------------|:------|
+| RabbitMQ instances  | The VMs on which RabbitMQ brokers will run                  | 3     |
+| Client instance     | The VM from which the benchmarking suite itself will be run | 1     |
+| Prometheus instance | The VM on which metrics services will be run                | 1     |
 
 When you run `terraform apply`, you will be prompted to type `yes`. Type `yes` to continue with the installation or anything else to quit.
 
@@ -115,10 +116,18 @@ $ sudo bin/benchmark --drivers driver-rabbotmq/rabbitmq.yaml workloads/1-topic-1
 
 ## Monitoring
 
-The `rabbitmq_management` plugin is installed, and the HTTP endpoint is exposed on all RabbitMQ instances on port
-`15672`. This allows access to the management UI which provides some basic status metrics. It should also be possible
-to access the management REST API at this endpoint.
+### Native
+The `rabbitmq_management` plugin is installed, and the HTTP endpoint is **publicly** exposed on all RabbitMQ instances
+on port `15672`. This allows access to the management UI which provides some basic status metrics. It should also be
+possible to access the management REST API at this endpoint.
 
 Note that the connection is authenticated but not currently encrypted and so passwords will be passed in plain text. Use
 the `admin` account configured in the [Terraform](deploy/provision-rabbitmq-aws.tf) file to log in.
+
+### Prometheus
+The `rabbitmq_prometheus` plugin is installed and Prometheus is installed on a standalone instance. This exposes a
+public endpoint `http://${prometheus_host}:9090`.
+
+See 
+'[RabbitMQ.com — Monitoring with Prometheus & Grafana](https://www.rabbitmq.com/prometheus.html)' for more information.
 

--- a/driver-rabbitmq/README.md
+++ b/driver-rabbitmq/README.md
@@ -134,5 +134,5 @@ public endpoint `http://${prometheus_host}:9090`. See
 ### Grafana
 
 Grafana and [RabbitMQ's standard dashboards](https://grafana.com/rabbitmq) are installed alongside Prometheus. These
-are exposed on a public endpoint `http://${prometheus_host}:3000`.
+are exposed on a public endpoint `http://${prometheus_host}:3000`. Credentials are `admin`/`admin`.
 

--- a/driver-rabbitmq/README.md
+++ b/driver-rabbitmq/README.md
@@ -117,6 +117,7 @@ $ sudo bin/benchmark --drivers driver-rabbotmq/rabbitmq.yaml workloads/1-topic-1
 ## Monitoring
 
 ### Native
+
 The `rabbitmq_management` plugin is installed, and the HTTP endpoint is **publicly** exposed on all RabbitMQ instances
 on port `15672`. This allows access to the management UI which provides some basic status metrics. It should also be
 possible to access the management REST API at this endpoint.
@@ -125,11 +126,13 @@ Note that the connection is authenticated but not currently encrypted and so pas
 the `admin` account configured in the [Terraform](deploy/provision-rabbitmq-aws.tf) file to log in.
 
 ### Prometheus
+
 The `rabbitmq_prometheus` plugin is installed and Prometheus is installed on a standalone instance. This exposes a
 public endpoint `http://${prometheus_host}:9090`. See
 '[RabbitMQ.com — Monitoring with Prometheus & Grafana](https://www.rabbitmq.com/prometheus.html)' for more information.
 
 ### Grafana
+
 Grafana and [RabbitMQ's standard dashboards](https://grafana.com/rabbitmq) are installed alongside Prometheus. These
-are exposed on a public endpoint `http://${prometheus_host}:3000`. 
+are exposed on a public endpoint `http://${prometheus_host}:3000`.
 

--- a/driver-rabbitmq/deploy/deploy.yaml
+++ b/driver-rabbitmq/deploy/deploy.yaml
@@ -286,22 +286,6 @@
       when:
         - ansible_facts['distribution'] == 'RedHat'
         - ansible_facts['distribution_major_version'] | int <= 7
-    - name: Docker repo
-      yum_repository:
-        name: docker
-        description: repo for docker
-        baseurl: "https://download.docker.com/linux/centos/{{ ansible_facts['distribution_major_version'] }}/x86_64/stable/"
-        gpgcheck: no
-      when: ansible_facts['distribution'] == 'RedHat'
-    - name: Installing docker
-      yum:
-        state: latest
-        pkg: ['docker-ce']
-    - name: Start docker
-      service:
-        name: docker
-        state: started
-        enabled: yes
     - file: path=/opt/prometheus state=absent
     - file: path=/opt/prometheus state=directory
     - name: Download Prometheus Binary Package
@@ -316,8 +300,8 @@
   connection: ssh
   become: true
   tasks:
-    - file: path=/opt/pulsar state=absent
-    - file: path=/opt/pulsar state=directory
+    - file: path=/opt/rabbitmq state=absent
+    - file: path=/opt/rabbitmq state=directory
     - file:
         path: "/opt/prometheus/{{ item }}"
         state: directory
@@ -334,6 +318,53 @@
         daemon_reload: yes
         name: "prometheus"
 
+- name: Grafana installation
+  hosts: prometheus
+  connection: ssh
+  become: true
+  tasks:
+    - name: Docker repo
+      yum_repository:
+        name: docker
+        description: repo for docker
+        baseurl: "https://download.docker.com/linux/centos/{{ ansible_facts['distribution_major_version'] }}/x86_64/stable/"
+        gpgcheck: no
+      when: ansible_facts['distribution'] == 'RedHat'
+    - name: Installing docker
+      yum:
+        state: latest
+        pkg: ['docker-ce']
+    - name: Start docker
+      service:
+        name: docker
+        state: started
+        enabled: yes
+    - file: path=/opt/grafana state=absent
+    - file: path=/opt/grafana state=directory
+    - file: path=/repos state=absent
+    - file: path=/repos state=directory
+    - name: Clone a RabbitMQ repository
+      git:
+        repo: https://github.com/rabbitmq/rabbitmq-server.git
+        dest: /repos
+        clone: yes
+        update: yes
+
+- name: Grafana setup
+  hosts: prometheus
+  connection: ssh
+  become: true
+  tasks:
+    - file: path=/opt/rabbitmq state=absent
+    - file: path=/opt/rabbitmq state=directory
+    - template:
+        src: "templates/rabbitmq-dashboard.service"
+        dest: "/etc/systemd/system/rabbitmq-dashboard.service"
+    - systemd:
+        state: restarted
+        daemon_reload: yes
+        name: "rabbitmq-dashboard.service"
+
 - name: List host addresses
   hosts: localhost
   become: false
@@ -347,4 +378,3 @@
     - debug:
         msg: "Prometheus servers {{ item }}"
       with_items: "{{ groups['prometheus'] }}"
-  

--- a/driver-rabbitmq/deploy/deploy.yaml
+++ b/driver-rabbitmq/deploy/deploy.yaml
@@ -362,6 +362,9 @@
     - file: path=/opt/rabbitmq state=absent
     - file: path=/opt/rabbitmq state=directory
     - template:
+        src: "templates/grafana-datasource.yml"
+        dest: "/opt/rabbitmq/grafana-datasource.yml"
+    - template:
         src: "templates/rabbitmq-dashboard.service"
         dest: "/etc/systemd/system/rabbitmq-dashboard.service"
     - systemd:

--- a/driver-rabbitmq/deploy/deploy.yaml
+++ b/driver-rabbitmq/deploy/deploy.yaml
@@ -79,6 +79,12 @@
       state: restarted
       daemon_reload: yes
       name: "rabbitmq-server"
+  - name: Install Prometheus monitoring
+    shell: rabbitmq-plugins enable rabbitmq_prometheus
+  - systemd:
+      state: restarted
+      daemon_reload: yes
+      name: "rabbitmq-server"
 
   - name: Clear servers' Erlang cookie
     file:
@@ -146,6 +152,69 @@
         daemon_reload: yes
         name: "chronyd"
 
+- name: Install RabbitMQ Prometheus node exporters
+  hosts: rabbitmq
+  connection: ssh
+  become: true
+  tasks:
+    - set_fact:
+        nodeExporterVersion: 1.2.2
+    - set_fact:
+        nodeExporterBinary:
+          src: "https://github.com/prometheus/node_exporter/releases/download/v{{ nodeExporterVersion }}/node_exporter-{{ nodeExporterVersion }}.linux-amd64.tar.gz"
+          remote: yes
+      when: nodeExporterBinary is not defined
+    - name: Add user node_exporter
+      user:
+        name: node_exporter
+        shell: /bin/false
+        system: true
+        create_home: no
+    - name: Download and extract
+      unarchive:
+        src: "{{ nodeExporterBinary.src }}"
+        dest: /tmp
+        remote_src: "{{ nodeExporterBinary.remote }}"
+
+    - name: Copy bin node_exporter to /usr/local/bin
+      copy:
+        src: "/tmp/node_exporter-{{ nodeExporterVersion }}.linux-amd64/node_exporter"
+        remote_src: yes
+        dest: /usr/local/bin/
+        owner: node_exporter
+        group: node_exporter
+        mode: u+x,g+x,o+x
+
+    - name: Create service node_exporter.service
+      blockinfile:
+        path: /etc/systemd/system/node_exporter.service
+        block: |
+          [Unit]
+          Description=Prometheus Node Exporter
+          Wants=network-online.target
+          After=network-online.target
+          [Service]
+          User=node_exporter
+          Group=node_exporter
+          Type=simple
+          ExecStart=/usr/local/bin/node_exporter
+          [Install]
+          WantedBy=multi-user.target
+        create: true
+    - name: systemctl daemon_reload
+      systemd:
+        daemon_reload: yes
+    - name: Start and Enable node_exporter
+      service:
+        name: node_exporter
+        state: started
+        enabled: yes
+    - name: Check whether port 9100 is available
+      wait_for:
+        port: 9100
+        state: started
+        timeout: 5
+
 - name: RabbitMQ benchmarking client setup
   hosts: client
   connection: ssh
@@ -201,6 +270,70 @@
         name: "benchmark-worker"
       tags: [client-code]
 
+- name: Prometheus installation
+  hosts: prometheus
+  connection: ssh
+  become: true
+  tasks:
+    - set_fact:
+        prometheusVersion: 2.31.1
+    - set_fact:
+        prometheusBinary:
+          src: "https://github.com/prometheus/prometheus/releases/download/v{{ prometheusVersion }}/prometheus-{{ prometheusVersion }}.linux-amd64.tar.gz"
+          remote: yes
+    - name: Add Extras Repo
+      shell: yum-config-manager --enable rhui-REGION-rhel-server-extras
+      when:
+        - ansible_facts['distribution'] == 'RedHat'
+        - ansible_facts['distribution_major_version'] | int <= 7
+    - name: Docker repo
+      yum_repository:
+        name: docker
+        description: repo for docker
+        baseurl: "https://download.docker.com/linux/centos/{{ ansible_facts['distribution_major_version'] }}/x86_64/stable/"
+        gpgcheck: no
+      when: ansible_facts['distribution'] == 'RedHat'
+    - name: Installing docker
+      yum:
+        state: latest
+        pkg: ['docker-ce']
+    - name: Start docker
+      service:
+        name: docker
+        state: started
+        enabled: yes
+    - file: path=/opt/prometheus state=absent
+    - file: path=/opt/prometheus state=directory
+    - name: Download Prometheus Binary Package
+      unarchive:
+        src: "{{ prometheusBinary.src }}"
+        remote_src: "{{ prometheusBinary.remote }}"
+        dest: /opt/prometheus
+        extra_opts: ["--strip-components=1"]
+
+- name: Prometheus setup
+  hosts: prometheus
+  connection: ssh
+  become: true
+  tasks:
+    - file: path=/opt/pulsar state=absent
+    - file: path=/opt/pulsar state=directory
+    - file:
+        path: "/opt/prometheus/{{ item }}"
+        state: directory
+      with_items:
+        - data
+    - template:
+        src: "templates/prometheus.service"
+        dest: "/etc/systemd/system/prometheus.service"
+    - template:
+        src: "templates/prometheus.yml"
+        dest: "/opt/prometheus/prometheus.yml"
+    - systemd:
+        state: restarted
+        daemon_reload: yes
+        name: "prometheus"
+
 - name: List host addresses
   hosts: localhost
   become: false
@@ -211,4 +344,7 @@
     - debug:
         msg: "Benchmark client {{ item }}"
       with_items: "{{ groups['client'] }}"
+    - debug:
+        msg: "Prometheus servers {{ item }}"
+      with_items: "{{ groups['prometheus'] }}"
   

--- a/driver-rabbitmq/deploy/deploy.yaml
+++ b/driver-rabbitmq/deploy/deploy.yaml
@@ -341,12 +341,16 @@
         enabled: yes
     - file: path=/opt/grafana state=absent
     - file: path=/opt/grafana state=directory
-    - file: path=/repos state=absent
-    - file: path=/repos state=directory
+    - file: path=/repos/rabbitmq-server state=absent
+    - file: path=/repos/rabbitmq-server state=directory
+    - name: Install RPM packages
+      yum: pkg={{ item }} state=latest
+      with_items:
+        - git
     - name: Clone a RabbitMQ repository
       git:
         repo: https://github.com/rabbitmq/rabbitmq-server.git
-        dest: /repos
+        dest: /repos/rabbitmq-server
         clone: yes
         update: yes
 

--- a/driver-rabbitmq/deploy/deploy.yaml
+++ b/driver-rabbitmq/deploy/deploy.yaml
@@ -17,13 +17,13 @@
   connection: ssh
   become: true
   tasks:
-    - name: Format disks
+    - name: RabbitMQ - Format disks
       filesystem:
         fstype: xfs
         dev: '{{ item }}'
       with_items:
         - '/dev/nvme1n1'
-    - name: Mount disks
+    - name: RabbitMQ - Mount disks
       mount:
         path: "{{ item.path }}"
         src: "{{ item.src }}"
@@ -32,7 +32,7 @@
         state: mounted
       with_items:
         - { path: "/mnt/data", src: "/dev/nvme1n1" }
-    - name: Set permissions
+    - name: RabbitMQ - Set filesystem permissions
       file:
         path: "/mnt/data"
         state: touch
@@ -42,103 +42,107 @@
   hosts: rabbitmq
   connection: ssh
   tasks:
-  - set_fact:
+  - name: RabbitMQ - Set software versions
+    set_fact:
       erlangVersion: 24.3.4.5
       rabbitMqVersion: 3.10.7
-  - name: Install RPM packages
+  - name: RabbitMQ - Install RPM packages
     yum: pkg={{ item }} state=latest
     with_items:
       - wget
       - sysstat
       - vim
       - socat
-  - name: Install Erlang
+  - name: RabbitMQ - Install Erlang
     yum:
       name: https://github.com/rabbitmq/erlang-rpm/releases/download/v{{ erlangVersion }}/erlang-{{ erlangVersion }}-1.el8.x86_64.rpm
       state: present
       disable_gpg_check: yes
-  - name: Install Rabbitmq Server
+  - name: RabbitMQ - Install RabbitMQ Server
     yum:
       name: https://github.com/rabbitmq/rabbitmq-server/releases/download/v{{ rabbitMqVersion }}/rabbitmq-server-{{ rabbitMqVersion }}-1.el8.noarch.rpm
       state: present
       disable_gpg_check: yes
 
-  - name: Create rabbitmq-env.conf file
+  - name: RabbitMQ - Create rabbitmq-env.conf file
     template:
       src: "templates/rabbitmq-env.conf"
       dest: "/etc/rabbitmq/rabbitmq-env.conf"
 
-  - systemd:
+  - name: RabbitMQ - Start standalone
+    systemd:
       state: started
       daemon_reload: yes
       name: "rabbitmq-server"
 
-  - name: Install web management
+  - name: RabbitMQ - Install web management plugin
     shell: rabbitmq-plugins enable rabbitmq_management
   - systemd:
       state: restarted
       daemon_reload: yes
       name: "rabbitmq-server"
-  - name: Install Prometheus monitoring
+  - name: RabbitMQ - Install Prometheus monitoring plugin
     shell: rabbitmq-plugins enable rabbitmq_prometheus
-  - systemd:
+  - name: RabbitMQ - Restart standalone
+    systemd:
       state: restarted
       daemon_reload: yes
       name: "rabbitmq-server"
 
-  - name: Clear servers' Erlang cookie
+  - name: RabbitMQ - Clear Erlang cookie
     file:
       path: /var/lib/rabbitmq/.erlang.cookie
       state: absent
-  - name: Copy Erlang cookie
+  - name: RabbitMQ - Copy Erlang cookie
     copy: src=erlang.cookie  dest=/var/lib/rabbitmq/.erlang.cookie  owner=rabbitmq group=rabbitmq mode=0400
-  - systemd:
+  - name: RabbitMQ - Restart standalone
+    systemd:
       state: restarted
       daemon_reload: yes
       name: "rabbitmq-server"
     tags: [restart-rabbitmq]
 
-  - name: RabbitMQ status
+  - name: RabbitMQ - Check cluster status
     shell: rabbitmqctl cluster_status
     register: result
   - debug:
       msg: '{{ result.stdout }}'
 
-  - name: Rabbit cluster stop slaves
+  - name: RabbitMQ - Stop cluster followers
     shell: rabbitmqctl stop_app
     when: inventory_hostname != hostvars[groups['rabbitmq'][0]].inventory_hostname
 
-  - name: Rabbit cluster slaves join master
+  - name: RabbitMQ - Join followers to leader
     shell: rabbitmqctl join_cluster rabbit@{{ hostvars[groups['rabbitmq'][0]].private_ip }}
     when: inventory_hostname != hostvars[groups['rabbitmq'][0]].inventory_hostname
 
-  - name: Rabbit set cluster name
+  - name: RabbitMQ - Set cluster name
     shell: rabbitmqctl set_cluster_name benchmark_rabbitmq
     when: inventory_hostname == hostvars[groups['rabbitmq'][0]].inventory_hostname
 
-  - name: Start RabbitMQ cluster slaves
+  - name: RabbitMQ - Start cluster followers
     shell: rabbitmqctl start_app
     when: inventory_hostname != hostvars[groups['rabbitmq'][0]].inventory_hostname
 
-  - name: Show RabbitMQ cluster status
+  - name: RabbitMQ - Show cluster status
     shell: rabbitmqctl cluster_status
     register: result
   - debug:
       msg: '{{ result.stdout }}'
 
-  - name: create admin/admin profile
+  - name: RabbitMQ - Create admin/admin profile
     shell:  rabbitmqctl add_user admin  admin
     when: inventory_hostname == hostvars[groups['rabbitmq'][0]].inventory_hostname
 
-  - name: set admin tag
+  - name: RabbitMQ - Set admin tag
     shell: rabbitmqctl set_user_tags admin administrator
     when: inventory_hostname == hostvars[groups['rabbitmq'][0]].inventory_hostname
 
-  - name: set admin permission
+  - name: RabbitMQ - Set admin permission
     shell: rabbitmqctl set_permissions -p "/" admin ".*" ".*" ".*"
     when: inventory_hostname == hostvars[groups['rabbitmq'][0]].inventory_hostname
 
-  - name: Create high availability policy
+  - name: RabbitMQ - Create high availability policy
     shell: rabbitmqctl set_policy ha-all "^" '{"ha-mode":"exactly","ha-params":2,"ha-sync-mode":"automatic"}'
     when: inventory_hostname == hostvars[groups['rabbitmq'][0]].inventory_hostname
 
@@ -147,11 +151,12 @@
   connection: ssh
   become: true
   tasks:
-    - name: Set up chronyd
+    - name: Chrony - Configure
       template:
         src: "templates/chrony.conf"
         dest: "/etc/chrony.conf"
-    - systemd:
+    - name: Chrony - Restart
+      systemd:
         state: restarted
         daemon_reload: yes
         name: "chronyd"
@@ -161,26 +166,27 @@
   connection: ssh
   become: true
   tasks:
-    - set_fact:
+    - name: NodeExporter - Set software versions
+      set_fact:
         nodeExporterVersion: 1.2.2
-    - set_fact:
+    - name: NodeExporter - Set binary source URL
+      set_fact:
         nodeExporterBinary:
           src: "https://github.com/prometheus/node_exporter/releases/download/v{{ nodeExporterVersion }}/node_exporter-{{ nodeExporterVersion }}.linux-amd64.tar.gz"
           remote: yes
       when: nodeExporterBinary is not defined
-    - name: Add user node_exporter
+    - name: NodeExporter - Add node_exporter user
       user:
         name: node_exporter
         shell: /bin/false
         system: true
         create_home: no
-    - name: Download and extract
+    - name: NodeExporter - Download and extract
       unarchive:
         src: "{{ nodeExporterBinary.src }}"
         dest: /tmp
         remote_src: "{{ nodeExporterBinary.remote }}"
-
-    - name: Copy bin node_exporter to /usr/local/bin
+    - name: NodeExporter - Install binary
       copy:
         src: "/tmp/node_exporter-{{ nodeExporterVersion }}.linux-amd64/node_exporter"
         remote_src: yes
@@ -188,8 +194,7 @@
         owner: node_exporter
         group: node_exporter
         mode: u+x,g+x,o+x
-
-    - name: Create service node_exporter.service
+    - name: NodeExporter - Create service
       blockinfile:
         path: /etc/systemd/system/node_exporter.service
         block: |
@@ -205,15 +210,15 @@
           [Install]
           WantedBy=multi-user.target
         create: true
-    - name: systemctl daemon_reload
+    - name: NodeExporter - Reload daemon configuration
       systemd:
         daemon_reload: yes
-    - name: Start and Enable node_exporter
+    - name: NodeExporter - Start and enable service
       service:
         name: node_exporter
         state: started
         enabled: yes
-    - name: Check whether port 9100 is available
+    - name: NodeExporter - Check port 9100 availability
       wait_for:
         port: 9100
         state: started
@@ -224,7 +229,9 @@
   connection: ssh
   become: true
   tasks:
-    - name: Install RPM packages
+    - name:  Benchmark - Tune kernel
+      shell: tuned-adm profile latency-performance
+    - name: Benchmark - Install RPM packages
       yum: pkg={{ item }} state=latest
       with_items:
         - wget
@@ -232,43 +239,43 @@
         - java-11-openjdk-devel
         - sysstat
         - vim
-    - name: Copy benchmark code
+    - name: Benchmark - Copy and unpack
       unarchive:
         src: ../../package/target/openmessaging-benchmark-0.0.1-SNAPSHOT-bin.tar.gz
         dest: /opt
       tags: [client-code]
-    - shell: mv /opt/openmessaging-benchmark-0.0.1-SNAPSHOT /opt/benchmark
+    - name: Benchmark - Install binary
+      shell: mv /opt/openmessaging-benchmark-0.0.1-SNAPSHOT /opt/benchmark
       tags: [client-code]
-    - shell: tuned-adm profile latency-performance
-
-    - template:
+    - name: Benchmark - Configure worker
+      template:
         src: "templates/workers.yaml"
         dest: "/opt/benchmark/workers.yaml"
       tags: [client-code]
-
-    - template:
+    - name: Benchmark - Configure driver
+      template:
         src: "templates/rabbitmq.yaml"
         dest: "/opt/benchmark/driver-rabbitmq/rabbitmq.yaml"
       tags: [client-code]
-
-    - name: Configure benchmark-worker memory
+    - name: Benchmark - Configure worker JVM memory
       lineinfile:
         dest: /opt/benchmark/bin/benchmark-worker
         regexp: '^JVM_MEM='
         line: 'JVM_MEM="-Xms100G -Xmx100G -XX:+UnlockExperimentalVMOptions -XX:+UseZGC -XX:+ParallelRefProcEnabled -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=12 -XX:ConcGCThreads=12 -XX:+DisableExplicitGC -XX:-ResizePLAB"'
       tags: [client-code]
-    - name: Configure benchmark memory
+    - name: Benchmark - Configure client JVM memory
       lineinfile:
         dest: /opt/benchmark/bin/benchmark
         regexp: '^JVM_MEM='
         line: 'JVM_MEM="-Xmx4G"'
       tags: [client-code]
-    - name: Install benchmark-worker systemd service
+    - name: Benchmark - Install systemd service
       template:
         src: "templates/benchmark-worker.service"
         dest: "/etc/systemd/system/benchmark-worker.service"
       tags: [client-code]
-    - systemd:
+    - name: Benchmark - Start worker
+      systemd:
         state: restarted
         daemon_reload: yes
         name: "benchmark-worker"
@@ -279,20 +286,23 @@
   connection: ssh
   become: true
   tasks:
-    - set_fact:
+    - name: Prometheus - Set software versions
+      set_fact:
         prometheusVersion: 2.31.1
-    - set_fact:
+    - name: Prometheus - Set binary source URL
+      set_fact:
         prometheusBinary:
           src: "https://github.com/prometheus/prometheus/releases/download/v{{ prometheusVersion }}/prometheus-{{ prometheusVersion }}.linux-amd64.tar.gz"
           remote: yes
-    - name: Add Extras Repo
+    - name: Prometheus - Add RHEL yum repo
       shell: yum-config-manager --enable rhui-REGION-rhel-server-extras
       when:
         - ansible_facts['distribution'] == 'RedHat'
         - ansible_facts['distribution_major_version'] | int <= 7
-    - file: path=/opt/prometheus state=absent
-    - file: path=/opt/prometheus state=directory
-    - name: Download Prometheus Binary Package
+    - name: Prometheus - Create install folders
+      file: path=/opt/prometheus/data state=absent
+    - file: path=/opt/prometheus/data state=directory
+    - name: Prometheus - Download and unarchive binary
       unarchive:
         src: "{{ prometheusBinary.src }}"
         remote_src: "{{ prometheusBinary.remote }}"
@@ -304,20 +314,16 @@
   connection: ssh
   become: true
   tasks:
-    - file: path=/opt/rabbitmq state=absent
-    - file: path=/opt/rabbitmq state=directory
-    - file:
-        path: "/opt/prometheus/{{ item }}"
-        state: directory
-      with_items:
-        - data
-    - template:
+    - name: Prometheus - Configure systemd
+      template:
         src: "templates/prometheus.service"
         dest: "/etc/systemd/system/prometheus.service"
-    - template:
+    - name: Prometheus - Configure service
+      template:
         src: "templates/prometheus.yml"
         dest: "/opt/prometheus/prometheus.yml"
-    - systemd:
+    - name: Prometheus - Restart service
+      systemd:
         state: restarted
         daemon_reload: yes
         name: "prometheus"
@@ -327,45 +333,46 @@
   connection: ssh
   become: true
   tasks:
-    - name: Docker repo
+    - name: Grafana - Configure yum Docker repo
       yum_repository:
         name: docker
         description: repo for docker
         baseurl: "https://download.docker.com/linux/centos/{{ ansible_facts['distribution_major_version'] }}/x86_64/stable/"
         gpgcheck: no
       when: ansible_facts['distribution'] == 'RedHat'
-    - name: Installing docker
+    - name: Grafana - Install Docker
       yum:
         state: latest
         pkg: ['docker-ce']
-    - name: Start docker
+    - name: Grafana - Start docker
       service:
         name: docker
         state: started
         enabled: yes
-    - file: path=/opt/grafana state=absent
+    - name: Grafana - Create install folders
+      file: path=/opt/grafana state=absent
     - file: path=/opt/grafana state=directory
     - file: path=/repos/rabbitmq-server state=absent
     - file: path=/repos/rabbitmq-server state=directory
     - file: path=/repos/grafana-dashboard state=absent
     - file: path=/repos/grafana-dashboard state=directory
-    - name: Install RPM packages
+    - name: Grafana - Install Git RPM packages
       yum: pkg={{ item }} state=latest
       with_items:
         - git
-    - name: Clone RabbitMQ repository
+    - name: Grafana - Clone RabbitMQ repository
       git:
         repo: https://github.com/rabbitmq/rabbitmq-server.git
         dest: /repos/rabbitmq-server
         clone: yes
         update: yes
-    - name: Clone rfmoz/grafana-dashboard repository
+    - name: Grafana - Clone rfmoz/grafana-dashboard repository
       git:
         repo: https://github.com/rfmoz/grafana-dashboards.git
         dest: /repos/grafana-dashboard
         clone: yes
         update: yes
-    - name: Copy node_exporter dashboard
+    - name: Grafana - Copy node_exporter dashboard
       copy: remote_src=True src=/repos/grafana-dashboard/prometheus/node-exporter-full.json dest=/repos/rabbitmq-server/deps/rabbitmq_prometheus/docker/grafana/dashboards/
 
 - name: Grafana setup
@@ -373,15 +380,19 @@
   connection: ssh
   become: true
   tasks:
-    - file: path=/opt/rabbitmq state=absent
+    - name: Grafana - Create data folders
+      file: path=/opt/rabbitmq state=absent
     - file: path=/opt/rabbitmq state=directory
-    - template:
+    - name: Grafana - Configure Prometheus datasource
+      template:
         src: "templates/grafana-datasource.yml"
         dest: "/opt/rabbitmq/grafana-datasource.yml"
-    - template:
+    - name: Grafana - Configure systemd
+      template:
         src: "templates/rabbitmq-dashboard.service"
         dest: "/etc/systemd/system/rabbitmq-dashboard.service"
-    - systemd:
+    - name: Grafana - Restart Grafana
+      systemd:
         state: restarted
         daemon_reload: yes
         name: "rabbitmq-dashboard.service"

--- a/driver-rabbitmq/deploy/provision-rabbitmq-aws.tf
+++ b/driver-rabbitmq/deploy/provision-rabbitmq-aws.tf
@@ -26,7 +26,7 @@ variable "az" {}
 variable "ami" {}
 
 provider "aws" {
-  region = "${var.region}"
+  region = var.region
 }
 
 # Create a VPC to launch our instances into
@@ -40,27 +40,27 @@ resource "aws_vpc" "benchmark_vpc" {
 
 # Create an internet gateway to give our subnet access to the outside world
 resource "aws_internet_gateway" "default" {
-  vpc_id = "${aws_vpc.benchmark_vpc.id}"
+  vpc_id = aws_vpc.benchmark_vpc.id
 }
 
 # Grant the VPC internet access on its main route table
 resource "aws_route" "internet_access" {
-  route_table_id         = "${aws_vpc.benchmark_vpc.main_route_table_id}"
+  route_table_id         = aws_vpc.benchmark_vpc.main_route_table_id
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = "${aws_internet_gateway.default.id}"
+  gateway_id             = aws_internet_gateway.default.id
 }
 
 # Create a subnet to launch our instances into
 resource "aws_subnet" "benchmark_subnet" {
-  vpc_id                  = "${aws_vpc.benchmark_vpc.id}"
+  vpc_id                  = aws_vpc.benchmark_vpc.id
   cidr_block              = "10.0.0.0/24"
   map_public_ip_on_launch = true
-  availability_zone       = "${var.az}"
+  availability_zone       = var.az
 }
 
 resource "aws_security_group" "benchmark_security_group" {
   name   = "terraform"
-  vpc_id = "${aws_vpc.benchmark_vpc.id}"
+  vpc_id = aws_vpc.benchmark_vpc.id
 
   # SSH access from anywhere
   ingress {
@@ -108,17 +108,17 @@ resource "aws_security_group" "benchmark_security_group" {
 }
 
 resource "aws_key_pair" "auth" {
-  key_name   = "${var.key_name}"
-  public_key = "${file(var.public_key_path)}"
+  key_name   = var.key_name
+  public_key = file(var.public_key_path)
 }
 
 resource "aws_instance" "rabbitmq" {
-  ami                    = "${var.ami}"
-  instance_type          = "${var.instance_types["rabbitmq"]}"
-  key_name               = "${aws_key_pair.auth.id}"
-  subnet_id              = "${aws_subnet.benchmark_subnet.id}"
-  vpc_security_group_ids = ["${aws_security_group.benchmark_security_group.id}"]
-  count                  = "${var.num_instances["rabbitmq"]}"
+  ami                    = var.ami
+  instance_type          = var.instance_types["rabbitmq"]
+  key_name               = aws_key_pair.auth.id
+  subnet_id              = aws_subnet.benchmark_subnet.id
+  vpc_security_group_ids = [aws_security_group.benchmark_security_group.id]
+  count                  = var.num_instances["rabbitmq"]
 
   tags = {
     Name = "rabbitmq_${count.index}"
@@ -126,12 +126,12 @@ resource "aws_instance" "rabbitmq" {
 }
 
 resource "aws_instance" "client" {
-  ami                    = "${var.ami}"
-  instance_type          = "${var.instance_types["client"]}"
-  key_name               = "${aws_key_pair.auth.id}"
-  subnet_id              = "${aws_subnet.benchmark_subnet.id}"
-  vpc_security_group_ids = ["${aws_security_group.benchmark_security_group.id}"]
-  count                  = "${var.num_instances["client"]}"
+  ami                    = var.ami
+  instance_type          = var.instance_types["client"]
+  key_name               = aws_key_pair.auth.id
+  subnet_id              = aws_subnet.benchmark_subnet.id
+  vpc_security_group_ids = [aws_security_group.benchmark_security_group.id]
+  count                  = var.num_instances["client"]
 
   tags = {
     Name = "rabbitmq_client_${count.index}"

--- a/driver-rabbitmq/deploy/provision-rabbitmq-aws.tf
+++ b/driver-rabbitmq/deploy/provision-rabbitmq-aws.tf
@@ -78,10 +78,18 @@ resource "aws_security_group" "benchmark_security_group" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  # Prometheus/Dashboard access
+  # Prometheus access
   ingress {
     from_port   = 9090
     to_port     = 9090
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Grafana access
+  ingress {
+    from_port   = 3000
+    to_port     = 3000
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }

--- a/driver-rabbitmq/deploy/provision-rabbitmq-aws.tf
+++ b/driver-rabbitmq/deploy/provision-rabbitmq-aws.tf
@@ -148,7 +148,7 @@ resource "aws_instance" "prometheus" {
   count = var.num_instances["prometheus"]
 
   tags = {
-    Name = "prometheus-${count.index}"
+    Name = "prometheus_${count.index}"
   }
 }
 

--- a/driver-rabbitmq/deploy/templates/grafana-datasource.yml
+++ b/driver-rabbitmq/deploy/templates/grafana-datasource.yml
@@ -1,3 +1,17 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 apiVersion: 1
 
 datasources:

--- a/driver-rabbitmq/deploy/templates/grafana-datasource.yml
+++ b/driver-rabbitmq/deploy/templates/grafana-datasource.yml
@@ -1,8 +1,8 @@
 apiVersion: 1
 
 datasources:
-  {% for prom in groups['prometheus'] %}
-  - name: {{ hostvars[prom].private_ip }}
+{% for prom in groups['prometheus'] %}
+  - name: {{ hostvars[prom].inventory_hostname }}
     url: http://{{ hostvars[prom].private_ip }}:9090
     type: prometheus
     access: proxy
@@ -10,4 +10,4 @@ datasources:
     isDefault: true
     version: 1
     editable: false
-  {% endfor %}
+{% endfor %}

--- a/driver-rabbitmq/deploy/templates/grafana-datasource.yml
+++ b/driver-rabbitmq/deploy/templates/grafana-datasource.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+datasources:
+  {% for prom in groups['prometheus'] %}
+  - name: {{ hostvars[prom].private_ip }}
+    url: http://{{ hostvars[prom].private_ip }}:9090
+    type: prometheus
+    access: proxy
+    orgId: 1
+    isDefault: true
+    version: 1
+    editable: false
+  {% endfor %}

--- a/driver-rabbitmq/deploy/templates/prometheus.service
+++ b/driver-rabbitmq/deploy/templates/prometheus.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Prometheus server
+After=network.target
+
+[Service]
+WorkingDirectory=/opt/prometheus
+ExecStart=/opt/prometheus/prometheus \
+    --web.enable-admin-api \
+    --storage.tsdb.path=/opt/prometheus/data \
+    --config.file=/opt/prometheus/prometheus.yml
+
+[Install]
+WantedBy=multi-user.target

--- a/driver-rabbitmq/deploy/templates/prometheus.yml
+++ b/driver-rabbitmq/deploy/templates/prometheus.yml
@@ -1,0 +1,45 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+---
+global:
+  scrape_interval:     10s # By default, scrape targets every 15 seconds.
+  evaluation_interval: 10s # By default, scrape targets every 15 seconds.
+  # scrape_timeout is set to the global default (10s).
+  external_labels:
+    # TODO: replace `<cluster-name>` with the right cluster name. E.g.
+    #
+    # cluster: test-cluster
+    cluster: local
+
+# Load and evaluate rules in these files every 'evaluation_interval' seconds.
+# rule_files:
+
+scrape_configs:
+
+  - job_name: "broker"
+    honor_labels: true # don't overwrite job & instance labels
+    static_configs:
+      - targets:
+{% for broker in groups['rabbitmq'] %}
+          - {{ hostvars[broker].private_ip }}:15692
+{% endfor %}
+
+  - job_name: "node_metrics"
+    honor_labels: true # don't overwrite job & instance labels
+    static_configs:
+      - targets:
+{% for broker in groups['rabbitmq'] %}
+          - {{ hostvars[broker].private_ip }}:9100
+{% endfor %}

--- a/driver-rabbitmq/deploy/templates/rabbitmq-dashboard.service
+++ b/driver-rabbitmq/deploy/templates/rabbitmq-dashboard.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Pulsar Dashboard
+After=prometheus.service
+Requires=prometheus.service
+ 
+[Service]
+WorkingDirectory=/opt/grafana
+ExecStartPre=/usr/bin/docker pull grafana/grafana:8.3.4
+ExecStart=/usr/bin/docker run \
+  --restart=always \
+  --name=systemd_rabbitmq_dashboard \
+  -p3000:3000 \
+  -e GF_INSTALL_PLUGINS="flant-statusmap-panel,grafana-piechart-panel" \
+  -v /repos/rabbitmq-server/deps/rabbitmq_prometheus/docker/grafana/dashboards.yml:/etc/grafana/provisioning/dashboards/rabbitmq.yaml \
+  -v /repos/rabbitmq-server/deps/rabbitmq_prometheus/docker/grafana/datasources.yml:/etc/grafana/provisioning/datasources/prometheus.yaml \
+  -v /repos/rabbitmq-server/deps/rabbitmq_prometheus/docker/grafana/dashboards:/dashboards \
+  grafana/grafana:8.3.4
+ExecStop=/usr/bin/docker stop systemd_rabbitmq_dashboard
+ExecStopPost=/usr/bin/docker rm -f systemd_rabbitmq_dashboard
+ExecReload=/usr/bin/docker restart systemd_rabbitmq_dashboard
+ 
+[Install]
+WantedBy=multi-user.target

--- a/driver-rabbitmq/deploy/templates/rabbitmq-dashboard.service
+++ b/driver-rabbitmq/deploy/templates/rabbitmq-dashboard.service
@@ -11,8 +11,8 @@ ExecStart=/usr/bin/docker run \
   --name=systemd_rabbitmq_dashboard \
   -p3000:3000 \
   -e GF_INSTALL_PLUGINS="flant-statusmap-panel,grafana-piechart-panel" \
+  -v /opt/rabbitmq/grafana-datasource.yml:/etc/grafana/provisioning/datasources/prometheus.yaml \
   -v /repos/rabbitmq-server/deps/rabbitmq_prometheus/docker/grafana/dashboards.yml:/etc/grafana/provisioning/dashboards/rabbitmq.yaml \
-  -v /repos/rabbitmq-server/deps/rabbitmq_prometheus/docker/grafana/datasources.yml:/etc/grafana/provisioning/datasources/prometheus.yaml \
   -v /repos/rabbitmq-server/deps/rabbitmq_prometheus/docker/grafana/dashboards:/dashboards \
   grafana/grafana:8.3.4
 ExecStop=/usr/bin/docker stop systemd_rabbitmq_dashboard

--- a/driver-rabbitmq/deploy/terraform.tfvars
+++ b/driver-rabbitmq/deploy/terraform.tfvars
@@ -4,11 +4,13 @@ az              = "us-west-2a"
 ami             = "ami-08970fb2e5767e3b8" // RHEL-8
 
 instance_types = {
-  "rabbitmq"  = "i3en.6xlarge"
-  "client"    = "m5n.8xlarge"
+  "rabbitmq"   = "i3en.6xlarge"
+  "client"     = "m5n.8xlarge"
+  "prometheus" = "t2.large"
 }
 
 num_instances = {
-  "rabbitmq"    = 3
-  "client"      = 4
+  "rabbitmq"   = 1
+  "client"     = 1
+  "prometheus" = 1
 }

--- a/driver-rabbitmq/deploy/terraform.tfvars
+++ b/driver-rabbitmq/deploy/terraform.tfvars
@@ -10,7 +10,7 @@ instance_types = {
 }
 
 num_instances = {
-  "rabbitmq"   = 1
-  "client"     = 1
+  "rabbitmq"   = 3
+  "client"     = 4
   "prometheus" = 1
 }

--- a/driver-rabbitmq/rabbitmq.yaml
+++ b/driver-rabbitmq/rabbitmq.yaml
@@ -20,4 +20,4 @@ driverClass: io.openmessaging.benchmark.driver.rabbitmq.RabbitMqBenchmarkDriver
 
 amqpUris:
   - amqp://localhost
-messagePersistence: false
+messagePersistence: true

--- a/driver-rabbitmq/rabbitmq.yaml
+++ b/driver-rabbitmq/rabbitmq.yaml
@@ -20,4 +20,4 @@ driverClass: io.openmessaging.benchmark.driver.rabbitmq.RabbitMqBenchmarkDriver
 
 amqpUris:
   - amqp://localhost
-messagePersistence: true
+messagePersistence: false


### PR DESCRIPTION
# Motivation
RabbitMQ performance is quite unpredictable. It would be useful to have internal RMQ and node metrics to better understand bottlenecks.

# Changes
* Add a monitoring instance
* Install prometheus and grafana on monitoring instance
* Install recommended RMQ dashboards
* Install `node_exporter` and `rabbitmq_prometheus` on all brokers
* Expose prometheus and grafana UI ports