### PR TITLE
[RabbitMQ] Queue type configuration option

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Benchmark.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Benchmark.java
@@ -141,7 +141,7 @@ public class Benchmark {
 
         if (arguments.workers != null && !arguments.workers.isEmpty()) {
             List<Worker> workers =
-                    arguments.workers.stream().map(w -> new HttpWorkerClient(w)).collect(toList());
+                    arguments.workers.stream().map(HttpWorkerClient::new).collect(toList());
             worker = new DistributedWorkersEnsemble(workers, arguments.extraConsumers);
         } else {
             // Use local worker implementation
@@ -183,12 +183,8 @@ public class Benchmark {
                                                             driverConfiguration.name,
                                                             dateFormat.format(new Date()));
 
-                                    log.info("Writing test result into {}/{}", workloadName, fileName);
-                                    File folder = new File(workloadName);
-                                    if (!folder.mkdirs()) {
-                                        log.debug("Unable to create folder {}", folder);
-                                    }
-                                    writer.writeValue(new File(folder, fileName), result);
+                                    log.info("Writing test result into {}", fileName);
+                                    writer.writeValue(new File(fileName), result);
 
                                     generator.close();
                                 } catch (Exception e) {

--- a/driver-rabbitmq/README.md
+++ b/driver-rabbitmq/README.md
@@ -104,13 +104,13 @@ Once you've successfully SSHed into the client host, you can run all [available 
 
 ```bash
 $ cd /opt/benchmark
-$ sudo bin/benchmark --drivers driver-rabbitmq/rabbitmq.yaml workloads/*.yaml
+$ sudo bin/benchmark --drivers driver-rabbitmq/rabbitmq-classic.yaml workloads/*.yaml
 ```
 
 You can also run specific workloads in the `workloads` folder. Here's an example:
 
 ```bash
-$ sudo bin/benchmark --drivers driver-rabbotmq/rabbitmq.yaml workloads/1-topic-1-partitions-1kb.yaml
+$ sudo bin/benchmark --drivers driver-rabbotmq/rabbitmq-classic.yaml workloads/1-topic-1-partitions-1kb.yaml
 ```
 
 ## Monitoring

--- a/driver-rabbitmq/deploy/alicloud/deploy.yaml
+++ b/driver-rabbitmq/deploy/alicloud/deploy.yaml
@@ -197,7 +197,7 @@
         mv /opt/openmessaging-benchmark-0.0.1-SNAPSHOT /opt/benchmark
     - name: Configure service URL
       lineinfile:
-        dest: /opt/benchmark/driver-rabbitmq/rabbitmq.yaml
+        dest: /opt/benchmark/driver-rabbitmq/rabbitmq-classic.yaml
         regexp: '^brokerAddress\: '
         line: 'brokerAddress: rabbitmaster'
     - template:

--- a/driver-rabbitmq/deploy/deploy.yaml
+++ b/driver-rabbitmq/deploy/deploy.yaml
@@ -167,15 +167,17 @@
     - shell: mv /opt/openmessaging-benchmark-0.0.1-SNAPSHOT /opt/benchmark
       tags: [client-code]
     - shell: tuned-adm profile latency-performance
-
     - template:
         src: "templates/workers.yaml"
         dest: "/opt/benchmark/workers.yaml"
       tags: [client-code]
-
     - template:
-        src: "templates/rabbitmq.yaml"
-        dest: "/opt/benchmark/driver-rabbitmq/rabbitmq.yaml"
+        src: "templates/rabbitmq-classic.yaml"
+        dest: "/opt/benchmark/driver-rabbitmq/rabbitmq-classic.yaml"
+      tags: [client-code]
+    - template:
+        src: "templates/rabbitmq-quorum.yaml"
+        dest: "/opt/benchmark/driver-rabbitmq/rabbitmq-quorum.yaml"
       tags: [client-code]
 
     - name: Configure benchmark-worker memory

--- a/driver-rabbitmq/deploy/templates/rabbitmq-classic.yaml
+++ b/driver-rabbitmq/deploy/templates/rabbitmq-classic.yaml
@@ -19,6 +19,8 @@ driverClass: io.openmessaging.benchmark.driver.rabbitmq.RabbitMqBenchmarkDriver
 # RabbitMq client specific configurations
 
 amqpUris:
-  - amqp://localhost
-messagePersistence: false
+{% for pulsar in groups['rabbitmq'] %}
+  - amqp://admin:admin@{{ hostvars[pulsar].private_ip }}:5672
+{% endfor %}
+messagePersistence: true
 queueType: CLASSIC

--- a/driver-rabbitmq/deploy/templates/rabbitmq-quorum.yaml
+++ b/driver-rabbitmq/deploy/templates/rabbitmq-quorum.yaml
@@ -23,3 +23,4 @@ amqpUris:
   - amqp://admin:admin@{{ hostvars[pulsar].private_ip }}:5672
 {% endfor %}
 messagePersistence: false
+queueType: QUORUM

--- a/driver-rabbitmq/pom.xml
+++ b/driver-rabbitmq/pom.xml
@@ -39,5 +39,13 @@
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/driver-rabbitmq/rabbitmq.yaml
+++ b/driver-rabbitmq/rabbitmq.yaml
@@ -21,3 +21,4 @@ driverClass: io.openmessaging.benchmark.driver.rabbitmq.RabbitMqBenchmarkDriver
 amqpUris:
   - amqp://localhost
 messagePersistence: false
+queueType: CLASSIC

--- a/driver-rabbitmq/src/main/java/io/openmessaging/benchmark/driver/rabbitmq/RabbitMqBenchmarkDriver.java
+++ b/driver-rabbitmq/src/main/java/io/openmessaging/benchmark/driver/rabbitmq/RabbitMqBenchmarkDriver.java
@@ -30,7 +30,6 @@ import io.openmessaging.benchmark.driver.ConsumerCallback;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -129,11 +128,7 @@ public class RabbitMqBenchmarkDriver implements BenchmarkDriver {
                                 channel.exchangeDeclare(exchange, BuiltinExchangeType.FANOUT, true);
                                 // Create the queue
                                 channel.queueDeclare(
-                                        queueName,
-                                        true,
-                                        false,
-                                        false,
-                                        Collections.singletonMap("x-queue-type", "quorum"));
+                                        queueName, true, false, false, config.queueType.queueOptions());
                                 channel.queueBind(queueName, exchange, "");
                                 future.complete(
                                         new RabbitMqBenchmarkConsumer(channel, queueName, consumerCallback));

--- a/driver-rabbitmq/src/main/java/io/openmessaging/benchmark/driver/rabbitmq/RabbitMqConfig.java
+++ b/driver-rabbitmq/src/main/java/io/openmessaging/benchmark/driver/rabbitmq/RabbitMqConfig.java
@@ -13,13 +13,33 @@
  */
 package io.openmessaging.benchmark.driver.rabbitmq;
 
+import static io.openmessaging.benchmark.driver.rabbitmq.RabbitMqConfig.QueueType.CLASSIC;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 public class RabbitMqConfig {
 
     public List<String> amqpUris = new ArrayList<>();
-
     public boolean messagePersistence = false;
+    public QueueType queueType = CLASSIC;
+
+    public enum QueueType {
+        CLASSIC {
+            @Override
+            Map<String, Object> queueOptions() {
+                return Collections.emptyMap();
+            }
+        },
+        QUORUM {
+            @Override
+            Map<String, Object> queueOptions() {
+                return Collections.singletonMap("x-queue-type", "quorum");
+            }
+        };
+
+        abstract Map<String, Object> queueOptions();
+    }
 }

--- a/driver-rabbitmq/src/test/java/io/openmessaging/benchmark/driver/rabbitmq/QueueTypeTest.java
+++ b/driver-rabbitmq/src/test/java/io/openmessaging/benchmark/driver/rabbitmq/QueueTypeTest.java
@@ -1,3 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.openmessaging.benchmark.driver.rabbitmq;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/driver-rabbitmq/src/test/java/io/openmessaging/benchmark/driver/rabbitmq/QueueTypeTest.java
+++ b/driver-rabbitmq/src/test/java/io/openmessaging/benchmark/driver/rabbitmq/QueueTypeTest.java
@@ -1,0 +1,23 @@
+package io.openmessaging.benchmark.driver.rabbitmq;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class QueueTypeTest {
+
+    @Test
+    public void classic() {
+        assertThat(RabbitMqConfig.QueueType.CLASSIC.queueOptions()).isEmpty();
+    }
+
+    @Test
+    public void quorum() {
+        assertThat(RabbitMqConfig.QueueType.QUORUM.queueOptions())
+                .satisfies(
+                        o -> {
+                            assertThat(o).containsEntry("x-queue-type", "quorum");
+                            assertThat(o).hasSize(1);
+                        });
+    }
+}

--- a/driver-rabbitmq/src/test/java/io/openmessaging/benchmark/driver/rabbitmq/RabbitMqConfigTest.java
+++ b/driver-rabbitmq/src/test/java/io/openmessaging/benchmark/driver/rabbitmq/RabbitMqConfigTest.java
@@ -1,0 +1,37 @@
+package io.openmessaging.benchmark.driver.rabbitmq;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+class RabbitMqConfigTest {
+
+    @Test
+    public void deserialize() throws JsonProcessingException {
+        String config =
+                "{\"amqpUris\":[\"amqp://local\"],\"messagePersistence\":true,\"queueType\":\"QUORUM\"}";
+        RabbitMqConfig value = new ObjectMapper().readValue(config, RabbitMqConfig.class);
+        assertThat(value)
+                .satisfies(
+                        v -> {
+                            assertThat(v.amqpUris).containsOnly("amqp://local");
+                            assertThat(v.messagePersistence).isTrue();
+                            assertThat(v.queueType).isEqualTo(RabbitMqConfig.QueueType.QUORUM);
+                        });
+    }
+
+    @Test
+    public void deserializeWithDefaults() throws JsonProcessingException {
+        String config = "{\"amqpUris\":[\"amqp://local\"]}";
+        RabbitMqConfig value = new ObjectMapper().readValue(config, RabbitMqConfig.class);
+        assertThat(value)
+                .satisfies(
+                        v -> {
+                            assertThat(v.amqpUris).containsOnly("amqp://local");
+                            assertThat(v.messagePersistence).isFalse();
+                            assertThat(v.queueType).isEqualTo(RabbitMqConfig.QueueType.CLASSIC);
+                        });
+    }
+}

--- a/driver-rabbitmq/src/test/java/io/openmessaging/benchmark/driver/rabbitmq/RabbitMqConfigTest.java
+++ b/driver-rabbitmq/src/test/java/io/openmessaging/benchmark/driver/rabbitmq/RabbitMqConfigTest.java
@@ -1,3 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.openmessaging.benchmark.driver.rabbitmq;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
# Motivation
RabbitMQ supports multiple queue types. We have found behavioural differences between each type. Therefore it is useful for the type to be easily selectable by the user without code changes.

# Changes
* Introduced `QueueType` enum and configuration field
* Handles field when creating queues
* Related tests