### PR TITLE
[Feature] Proportional minimum backlog

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
@@ -51,6 +51,16 @@ public class Workload {
      * has drained all the backlog and it's on par with the producer
      */
     public long consumerBacklogSizeGB = 0;
+    /**
+     * The ratio of the backlog that can remain and yet the backlog still be considered empty, and
+     * thus the workload can complete at the end of the configured duration. In some systems it is not
+     * feasible for the backlog to be drained fully and thus the workload will run indefinitely. In
+     * such circumstances, one may be content to achieve a partial drain such as 99% of the backlog.
+     * The value should be on somewhere between 0.0 and 1.0, where 1.0 indicates that the backlog
+     * should be fully drained, and 0.0 indicates a best effort, where the workload will complete
+     * after the specified time irrespective of how much of the backlog has been drained.
+     */
+    public double backlogDrainRatio = 1.0;
 
     public int testDurationMinutes;
 

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
@@ -348,7 +348,7 @@ public class WorkloadGenerator implements AutoCloseable {
 
         // Add the topic multiple times, one for each producer
         for (int i = 0; i < workload.producersPerTopic; i++) {
-            topics.forEach(fullListOfTopics::add);
+            fullListOfTopics.addAll(topics);
         }
 
         Collections.shuffle(fullListOfTopics);
@@ -391,7 +391,9 @@ public class WorkloadGenerator implements AutoCloseable {
 
         worker.resumeConsumers();
 
-        final long minBacklog = 1000;
+        long backlogMessageCapacity = requestedBacklogSize / workload.messageSize;
+        long backlogEmptyLevel = (long) ((1.0 - workload.backlogDrainRatio) * backlogMessageCapacity);
+        final long minBacklog = Math.max(1000L, backlogEmptyLevel);
 
         while (true) {
             CountersStats stats = worker.getCountersStats();


### PR DESCRIPTION
# Motivation
The ratio of the backlog that can remain and yet the backlog still be considered empty, and thus the workload can complete at the end of the configured duration. In some systems it is not feasible for the backlog to be drained fully and thus the workload will run indefinitely and fail to write out a results file. In such circumstances, one may be content to achieve a partial drain such as 99% of the backlog.

# Changes
* `backlogDrainRatio` workload option
* Adjust minimum backlog based on configuration