### PR TITLE
[RMQ][TF] Use unique deployment resource names

### DIFF
--- a/driver-rabbitmq/deploy/provision-rabbitmq-aws.tf
+++ b/driver-rabbitmq/deploy/provision-rabbitmq-aws.tf
@@ -1,3 +1,14 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+    }
+    random = {
+      source  = "hashicorp/random"
+    }
+  }
+}
+
 variable "public_key_path" {
   description = <<DESCRIPTION
 Path to the SSH public key to be used for authentication.
@@ -8,8 +19,12 @@ Example: ~/.ssh/rabbitmq_aws.pub
 DESCRIPTION
 }
 
+resource "random_id" "hash" {
+  byte_length = 8
+}
+
 variable "key_name" {
-  default     = "rabbitmq-benchmark-key"
+  default     = "benchmark-key-rabbitmq"
   description = "Desired name of AWS key pair"
 }
 
@@ -34,7 +49,7 @@ resource "aws_vpc" "benchmark_vpc" {
   cidr_block = "10.0.0.0/16"
 
   tags = {
-    Name = "Benchmark-VPC"
+    Name = "Benchmark-VPC-RabbitMQ-${random_id.hash.hex}"
   }
 }
 
@@ -59,7 +74,7 @@ resource "aws_subnet" "benchmark_subnet" {
 }
 
 resource "aws_security_group" "benchmark_security_group" {
-  name   = "terraform"
+  name   = "terraform-rabbitmq-${random_id.hash.hex}"
   vpc_id = aws_vpc.benchmark_vpc.id
 
   # SSH access from anywhere
@@ -111,12 +126,12 @@ resource "aws_security_group" "benchmark_security_group" {
   }
 
   tags = {
-    Name = "Benchmark-Security-Group-RabbitMQ"
+    Name = "Benchmark-Security-Group-RabbitMQ-${random_id.hash.hex}"
   }
 }
 
 resource "aws_key_pair" "auth" {
-  key_name   = var.key_name
+  key_name   = "${var.key_name}-${random_id.hash.hex}"
   public_key = file(var.public_key_path)
 }
 


### PR DESCRIPTION
# Motivation
To run multiple benchmarks concurrently.

# Changes
* Introduce a random suffix to named resources.