### PR TITLE
[NATS] Improve write resiliancy

### DIFF
--- a/driver-nats/deploy/templates/cluster.conf
+++ b/driver-nats/deploy/templates/cluster.conf
@@ -18,6 +18,7 @@ server_name: {{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] 
 
 http: {{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}:8222
 jetstream: enabled
+write_deadline: 60
 
 jetstream {
     store_dir: /mnt/data

--- a/driver-nats/nats.yaml
+++ b/driver-nats/nats.yaml
@@ -17,4 +17,4 @@ driverClass: io.openmessaging.benchmark.driver.nats.NatsBenchmarkDriver
 
 natsHostUrl: localhost:4222
 
-replicationFactor: 1
+replicationFactor: 3

--- a/driver-nats/src/main/java/io/openmessaging/benchmark/driver/nats/NatsBenchmarkDriver.java
+++ b/driver-nats/src/main/java/io/openmessaging/benchmark/driver/nats/NatsBenchmarkDriver.java
@@ -37,6 +37,7 @@ import io.openmessaging.benchmark.driver.BenchmarkProducer;
 import io.openmessaging.benchmark.driver.ConsumerCallback;
 import java.io.File;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import org.apache.bookkeeper.stats.StatsLogger;
 import org.slf4j.Logger;
@@ -58,6 +59,9 @@ public class NatsBenchmarkDriver implements BenchmarkDriver {
                         new Options.Builder()
                                 .server(config.natsHostUrl)
                                 .maxReconnects(5)
+                                .reconnectWait(Duration.ofSeconds(1))
+                                .connectionTimeout(Duration.ofSeconds(5))
+                                .pingInterval(Duration.ofSeconds(60))
                                 .errorListener(
                                         new ErrorListener() {
                                             @Override


### PR DESCRIPTION
# Motivation
To have comparable configurations/behaviours across different messaging systems under test.

# Changes
* Increase replica count to 3
* Increase timeouts so that system does not so quickly terminate produce calls when under load.