### PR TITLE
[RMQ] Use 3 HA replicas for consistency

### DIFF
--- a/driver-rabbitmq/deploy/deploy.yaml
+++ b/driver-rabbitmq/deploy/deploy.yaml
@@ -143,7 +143,7 @@
     when: inventory_hostname == hostvars[groups['rabbitmq'][0]].inventory_hostname
 
   - name: RabbitMQ - Create high availability policy
-    shell: rabbitmqctl set_policy ha-all "^" '{"ha-mode":"exactly","ha-params":2,"ha-sync-mode":"automatic"}'
+    shell: rabbitmqctl set_policy ha-all "^" '{"ha-mode":"exactly","ha-params":3,"ha-sync-mode":"automatic"}'
     when: inventory_hostname == hostvars[groups['rabbitmq'][0]].inventory_hostname
 
 - name: Chrony setup


### PR DESCRIPTION
# Motivation
We would like benchmarks to be comparable across a range of messaging systems. Therefor we should aim for enabled feature parity.

# Changes
* Increase RabbitMQ queue replication to match that of Pulsar and NATS