### PR TITLE
[Feature] Interoperability of adaptive producer rates and the consumer backlog drain features

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/BenchmarkPhase.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/BenchmarkPhase.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openmessaging.benchmark;
+
+/** Used to indicate the Workload benchmarks phase. */
+public enum BenchmarkPhase {
+    /** The workload benchmark has not been invoked. */
+    IDLE,
+    /**
+     * The benchmark will connect to the system under test, potentially creating topics and
+     * subscriptions with brokers that do so eagerly.
+     */
+    INITIALIZE,
+    /**
+     * Benchmark is validating that a message can be passed from producer to consumer on each topic.
+     * This test exists to prime brokers that lazily create topics or subscriptions.
+     */
+    READINESS_CHECK,
+    /**
+     * Benchmark running a load through the system, producing at the requested target rate and
+     * consuming as quickly as possible. The benchmark will not collect any statistics in this phase.
+     */
+    WARM_UP,
+    /**
+     * Benchmark has stopped consumers and is building a backlog in the system under test to the
+     * requested size, using the target producer rate. The statistics gathered in this phase will
+     * contribute to the test results.
+     */
+    BACKLOG_FILL,
+    /**
+     * Benchmark has restarted consumers and will be consuming the backlog as quickly as possible. It
+     * continues to produce messages at the target producer rate. The test wil continue until the
+     * backlog is considered empty. The statistics gathered in this phase will contribute to the test
+     * results.
+     */
+    BACKLOG_DRAIN,
+    /**
+     * Benchmark is attempting to send messages at the target producer rate and consume them as
+     * quickly as possible. This phase will continue until the requested test duration has been
+     * achieved. The statistics gathered in this phase will contribute to the test results.
+     */
+    LOAD
+}

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/RateController.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/RateController.java
@@ -13,6 +13,8 @@
  */
 package io.openmessaging.benchmark;
 
+import static io.openmessaging.benchmark.BenchmarkPhase.BACKLOG_DRAIN;
+import static io.openmessaging.benchmark.BenchmarkPhase.BACKLOG_FILL;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static lombok.AccessLevel.PACKAGE;
 
@@ -42,7 +44,12 @@ class RateController {
         rampingFactor = maxRampingFactor;
     }
 
-    double nextRate(double rate, long periodNanos, long totalPublished, long totalReceived) {
+    double nextRate(
+            BenchmarkPhase phase,
+            double rate,
+            long periodNanos,
+            long totalPublished,
+            long totalReceived) {
         long expected = (long) ((rate / ONE_SECOND_IN_NANOS) * periodNanos);
         long published = totalPublished - previousTotalPublished;
         long received = totalReceived - previousTotalReceived;
@@ -59,7 +66,7 @@ class RateController {
         }
 
         long receiveBacklog = totalPublished - totalReceived;
-        if (receiveBacklog > receiveBacklogLimit) {
+        if (phase != BACKLOG_FILL && phase != BACKLOG_DRAIN && receiveBacklog > receiveBacklogLimit) {
             return nextRate(periodNanos, received, expected, receiveBacklog, "Receive");
         }
 


### PR DESCRIPTION
# Motivation
We would like to have the ability to set the produce throughput adaptively while running backlog drain benchmarks. For example, in a general load test we might want to attain the highest producer rate that does not incur any producer or consumer backlog. However, when filling a consumer backlog would not want the producer to back-off if the consumer backlog grows.

# Changes
* Introduced `BenchmarkPhase` enum
* Introduced a field in the `WorkloadGenerator` to track the current phase
* Added phase transitions in the `WorkloadGenerator`
* Updated rate controller to consider the phase, and specifically not back-off the producer rate in response to a consumer backlog in a drain test.
* Completed drain semantics modified: now looks for consumption of backlog, rather than an empty backlog.
