### PR TITLE
[Fix][NATS] Delivery group

### DIFF
--- a/driver-nats/deploy/deploy.yaml
+++ b/driver-nats/deploy/deploy.yaml
@@ -59,7 +59,7 @@
   - name: NATS - Install server
     tags: [ broker ]
     yum:
-      name: "https://github.com/nats-io/nats-server/releases/download/v2.9.3/nats-server-v2.9.3-amd64.rpm"
+      name: "https://github.com/nats-io/nats-server/releases/download/v2.9.6/nats-server-v2.9.6-amd64.rpm"
       state: present
       disable_gpg_check: yes
   - name: NATS - Apply server configuration

--- a/driver-nats/pom.xml
+++ b/driver-nats/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>io.nats</groupId>
             <artifactId>jnats</artifactId>
-            <version>2.15.6</version>
+            <version>2.16.3</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
# Motivation
NATS consumers are erroneously configured only to fan out. We need to be able to distribute messages across multiple consumers as is the case with other drivers.

# Changes
* Independently create NATS consumers and subscriptions
