### PR TITLE
[RMQ] Set partition handling behaviour

### DIFF
--- a/driver-rabbitmq/deploy/deploy.yaml
+++ b/driver-rabbitmq/deploy/deploy.yaml
@@ -64,6 +64,11 @@
       state: present
       disable_gpg_check: yes
 
+  - name: RabbitMQ - Create rabbitmq.conf file
+    template:
+      src: "templates/rabbitmq.conf"
+      dest: "/etc/rabbitmq/rabbitmq.conf"
+
   - name: RabbitMQ - Create rabbitmq-env.conf file
     template:
       src: "templates/rabbitmq-env.conf"

--- a/driver-rabbitmq/deploy/templates/rabbitmq.conf
+++ b/driver-rabbitmq/deploy/templates/rabbitmq.conf
@@ -1,0 +1,17 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+## Pauses all nodes on the minority side of a partition. The cluster
+## MUST have an odd number of nodes (3, 5, etc)
+cluster_partition_handling = pause_minority


### PR DESCRIPTION
# Motivation
To default to consistency in the event of a network partition, as is the expectation with many other systems tested by this benchmark.

# Changes
* Supply a RabbitMQ server config where in the event of a partition, the cluster will `pause_minority`