### PR TITLE
Batch producer/consumer creation

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/DriverConfiguration.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/DriverConfiguration.java
@@ -17,4 +17,8 @@ public class DriverConfiguration {
     public String name;
 
     public String driverClass;
+    public int createConsumerBatchSize;
+    public long createConsumerBatchDelay;
+    public int createProducerBatchSize;
+    public long createProducerBatchDelay;
 }

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/Batcher.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/utils/Batcher.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openmessaging.benchmark.utils;
+
+import static java.util.Collections.singletonList;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+public class Batcher<T> {
+
+    private final int maxBatchSize;
+
+    public Batcher(int maxBatchSize) {
+        this.maxBatchSize = maxBatchSize;
+    }
+
+    public List<List<T>> batch(List<T> list) {
+        if (maxBatchSize < 1) {
+            return singletonList(list);
+        }
+        AtomicInteger counter = new AtomicInteger();
+        return new ArrayList<>(
+                list.stream()
+                        .collect(Collectors.groupingBy(gr -> counter.getAndIncrement() / maxBatchSize))
+                        .values());
+    }
+}

--- a/driver-api/src/main/java/io/openmessaging/benchmark/driver/BenchmarkDriver.java
+++ b/driver-api/src/main/java/io/openmessaging/benchmark/driver/BenchmarkDriver.java
@@ -13,6 +13,7 @@
  */
 package io.openmessaging.benchmark.driver;
 
+import static java.util.stream.Collectors.toList;
 
 import java.io.File;
 import java.io.IOException;
@@ -76,6 +77,22 @@ public interface BenchmarkDriver extends AutoCloseable {
     CompletableFuture<BenchmarkProducer> createProducer(String topic);
 
     /**
+     * Create a producers for a given topic.
+     *
+     * @param producers
+     * @return a producer future
+     */
+    default CompletableFuture<List<BenchmarkProducer>> createProducers(List<ProducerInfo> producers) {
+        List<CompletableFuture<BenchmarkProducer>> futures =
+                producers.stream().map(ci -> createProducer(ci.getTopic())).collect(toList());
+        return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+                .thenApply(
+                        future -> {
+                            return futures.stream().map(CompletableFuture::join).collect(toList());
+                        });
+    }
+
+    /**
      * Create a benchmark consumer relative to one particular topic and subscription.
      *
      * <p>It is responsibility of the driver implementation to invoke the <code>consumerCallback
@@ -88,6 +105,39 @@ public interface BenchmarkDriver extends AutoCloseable {
      */
     CompletableFuture<BenchmarkConsumer> createConsumer(
             String topic, String subscriptionName, ConsumerCallback consumerCallback);
+
+    /**
+     * Create a consumers for a given topic.
+     *
+     * @param consumers
+     * @return a producer future
+     */
+    default CompletableFuture<List<BenchmarkConsumer>> createConsumers(List<ConsumerInfo> consumers) {
+        List<CompletableFuture<BenchmarkConsumer>> futures =
+                consumers.stream()
+                        .map(
+                                ci ->
+                                        createConsumer(
+                                                ci.getTopic(), ci.getSubscriptionName(), ci.getConsumerCallback()))
+                        .collect(toList());
+        return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+                .thenApply(
+                        future -> {
+                            return futures.stream().map(CompletableFuture::join).collect(toList());
+                        });
+    }
+
+    @Value
+    class ProducerInfo {
+        String topic;
+    }
+
+    @Value
+    class ConsumerInfo {
+        String topic;
+        String subscriptionName;
+        ConsumerCallback consumerCallback;
+    }
 
     @Value
     class TopicInfo {

--- a/driver-rabbitmq/deploy/templates/rabbitmq-quorum.yaml
+++ b/driver-rabbitmq/deploy/templates/rabbitmq-quorum.yaml
@@ -16,11 +16,16 @@
 name: RabbitMQ
 driverClass: io.openmessaging.benchmark.driver.rabbitmq.RabbitMqBenchmarkDriver
 
-# RabbitMq client specific configurations
+# RMQ struggles to create more than 10 quroum queues at a time, so we batch with a delay
+createConsumerBatchSize: 10
+createConsumerBatchDelay: 1000
+createProducerBatchSize: 10
+createProducerBatchDelay: 1000
 
 amqpUris:
 {% for pulsar in groups['rabbitmq'] %}
   - amqp://admin:admin@{{ hostvars[pulsar].private_ip }}:5672
 {% endfor %}
-messagePersistence: false
+
+# messagePersistence is not used by quorum queues
 queueType: QUORUM


### PR DESCRIPTION
# Motivation
Some systems become overwhelmed when asked to create many producers/consumers in a short period of time. This is possibly reasonable as it is an atypical use case. However, it is necessary for benchmarking. Therefore we need a strategy to effectively deal with this resource creation.

# Changes
* Added configurable batcher to feed producer/consumer create requests at a constant rate
* Default behaviour is no different from that or previous implementation
* Added config specific to RabbitMQ Quorum queues