### PR TITLE
Resilient resource creation

### DIFF
--- a/driver-api/src/main/java/io/openmessaging/benchmark/driver/ResourceCreator.java
+++ b/driver-api/src/main/java/io/openmessaging/benchmark/driver/ResourceCreator.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.openmessaging.benchmark.driver;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.stream.Collectors.toMap;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.Value;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class ResourceCreator<R, C> {
+    private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+    private final String name;
+    private final int maxBatchSize;
+    private final long interBatchDelayMs;
+    private final Function<List<R>, Map<R, CompletableFuture<C>>> invokeBatchFn;
+    private final Function<CompletableFuture<C>, CreationResult<C>> complete;
+
+    public CompletableFuture<List<C>> create(List<R> resources) {
+        return CompletableFuture.completedFuture(createBlocking(resources));
+    }
+
+    private List<C> createBlocking(List<R> resources) {
+        BlockingQueue<R> queue = new ArrayBlockingQueue<>(resources.size(), true, resources);
+        List<R> batch = new ArrayList<>();
+        List<C> created = new ArrayList<>();
+        AtomicInteger succeeded = new AtomicInteger();
+
+        ScheduledFuture<?> loggingFuture =
+                executor.scheduleAtFixedRate(
+                        () -> log.info("Created {}s {}/{}", name, succeeded.get(), resources.size()),
+                        10,
+                        10,
+                        SECONDS);
+
+        try {
+            while (succeeded.get() < resources.size()) {
+                int batchSize = queue.drainTo(batch, maxBatchSize);
+                if (batchSize > 0) {
+                    executeBatch(batch)
+                            .forEach(
+                                    (resource, result) -> {
+                                        if (result.success) {
+                                            created.add(result.created);
+                                            succeeded.incrementAndGet();
+                                        } else {
+                                            //noinspection ResultOfMethodCallIgnored
+                                            queue.offer(resource);
+                                        }
+                                    });
+                    batch.clear();
+                }
+            }
+        } finally {
+            loggingFuture.cancel(true);
+        }
+        return created;
+    }
+
+    @SneakyThrows
+    private Map<R, CreationResult<C>> executeBatch(List<R> batch) {
+        log.debug("Executing batch, size: {}", batch.size());
+        Thread.sleep(interBatchDelayMs);
+        return invokeBatchFn.apply(batch).entrySet().stream()
+                .collect(toMap(Map.Entry::getKey, e -> complete.apply(e.getValue())));
+    }
+
+    @Value
+    public static class CreationResult<C> {
+        C created;
+        boolean success;
+    }
+}

--- a/driver-rabbitmq/deploy/templates/rabbitmq-quorum.yaml
+++ b/driver-rabbitmq/deploy/templates/rabbitmq-quorum.yaml
@@ -18,9 +18,16 @@ driverClass: io.openmessaging.benchmark.driver.rabbitmq.RabbitMqBenchmarkDriver
 
 # RabbitMq client specific configurations
 
+# RMQ struggles to create more than 10 quroum queues at a time, so we batch with a delay
+producerCreationDelay: 100
+producerCreationBatchSize: 5
+consumerCreationDelay: 100
+consumerCreationBatchSize: 5
+
 amqpUris:
 {% for pulsar in groups['rabbitmq'] %}
   - amqp://admin:admin@{{ hostvars[pulsar].private_ip }}:5672
 {% endfor %}
-messagePersistence: false
+
+# messagePersistence setting is ignored in the quorum implementation
 queueType: QUORUM

--- a/driver-rabbitmq/rabbitmq.yaml
+++ b/driver-rabbitmq/rabbitmq.yaml
@@ -18,7 +18,12 @@ driverClass: io.openmessaging.benchmark.driver.rabbitmq.RabbitMqBenchmarkDriver
 
 # RabbitMq client specific configurations
 
+producerCreationDelay: 100
+producerCreationBatchSize: 5
+consumerCreationDelay: 100
+consumerCreationBatchSize: 5
+
 amqpUris:
   - amqp://localhost
 messagePersistence: false
-queueType: CLASSIC
+queueType: QUORUM

--- a/driver-rabbitmq/src/main/java/io/openmessaging/benchmark/driver/rabbitmq/RabbitMqConfig.java
+++ b/driver-rabbitmq/src/main/java/io/openmessaging/benchmark/driver/rabbitmq/RabbitMqConfig.java
@@ -25,6 +25,10 @@ public class RabbitMqConfig {
     public List<String> amqpUris = new ArrayList<>();
     public boolean messagePersistence = false;
     public QueueType queueType = CLASSIC;
+    public long producerCreationDelay = 100;
+    public int producerCreationBatchSize = 5;
+    public long consumerCreationDelay = 100;
+    public int consumerCreationBatchSize = 5;
 
     public enum QueueType {
         CLASSIC {

--- a/etc/findbugsExclude.xml
+++ b/etc/findbugsExclude.xml
@@ -126,4 +126,8 @@
     <Class name="io.openmessaging.benchmark.worker.WorkerStats" />
     <Bug pattern="EI_EXPOSE_REP" />
   </Match>
+  <Match>
+    <Class name="io.openmessaging.benchmark.driver.ResourceCreator" />
+    <Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE" />
+  </Match>
 </FindBugsFilter>


### PR DESCRIPTION
# Motivation
Some systems (notably RMQ) struggle to create large volumes of producers/consumers in a short period. This process needs to be more resilient, and to keep attempting to create these resources until they are successful.

# Changes
* Created a `ResoureCreator` that is based on the earlier `KafkaTopicCreator`
* Use this creator to instantiate consumers and producers in the RMQ driver
* Provide some configuration appropriate for RMQ Quorum Queues