### PR TITLE
[NATS] Extend to support in-memory stream

### DIFF
--- a/driver-nats/src/main/java/io/openmessaging/benchmark/driver/nats/NatsBenchmarkDriver.java
+++ b/driver-nats/src/main/java/io/openmessaging/benchmark/driver/nats/NatsBenchmarkDriver.java
@@ -28,7 +28,6 @@ import io.nats.client.Nats;
 import io.nats.client.Options;
 import io.nats.client.PushSubscribeOptions;
 import io.nats.client.api.ConsumerConfiguration;
-import io.nats.client.api.StorageType;
 import io.nats.client.api.StreamConfiguration;
 import io.nats.client.api.StreamInfo;
 import io.nats.client.support.JsonUtils;
@@ -94,7 +93,7 @@ public class NatsBenchmarkDriver implements BenchmarkDriver {
                             StreamConfiguration.builder()
                                     .name(topic)
                                     .subjects(topic)
-                                    .storageType(StorageType.File)
+                                    .storageType(config.storageType)
                                     .replicas(config.replicationFactor)
                                     .build());
             log.info("Created stream {} -- {}", topic, JsonUtils.getFormatted(streamInfo));

--- a/driver-nats/src/main/java/io/openmessaging/benchmark/driver/nats/NatsBenchmarkDriver.java
+++ b/driver-nats/src/main/java/io/openmessaging/benchmark/driver/nats/NatsBenchmarkDriver.java
@@ -94,6 +94,7 @@ public class NatsBenchmarkDriver implements BenchmarkDriver {
                                     .name(topic)
                                     .subjects(topic)
                                     .storageType(config.storageType)
+                                    .maxBytes(config.maxBytes)
                                     .replicas(config.replicationFactor)
                                     .build());
             log.info("Created stream {} -- {}", topic, JsonUtils.getFormatted(streamInfo));

--- a/driver-nats/src/main/java/io/openmessaging/benchmark/driver/nats/NatsConfig.java
+++ b/driver-nats/src/main/java/io/openmessaging/benchmark/driver/nats/NatsConfig.java
@@ -22,4 +22,7 @@ public class NatsConfig {
     public int replicationFactor;
 
     public StorageType storageType = StorageType.File;
+
+    // -1 is unlimited
+    public int maxBytes = -1;
 }

--- a/driver-nats/src/main/java/io/openmessaging/benchmark/driver/nats/NatsConfig.java
+++ b/driver-nats/src/main/java/io/openmessaging/benchmark/driver/nats/NatsConfig.java
@@ -13,8 +13,13 @@
  */
 package io.openmessaging.benchmark.driver.nats;
 
+
+import io.nats.client.api.StorageType;
+
 public class NatsConfig {
     public String natsHostUrl;
 
     public int replicationFactor;
+
+    public StorageType storageType = StorageType.File;
 }


### PR DESCRIPTION
## Motivation
While I was benchmarking NATS, I found myself needed to benchmark its in-memory stream. 
Think it would be beneficial to other folks with the option. 

## Changes
Extend `NatsConfig` with `storageType` and `maxBytes` to support in-memory stream while limiting memory consumption. 