### PR TITLE
Add max-rate 256kb workloads, missing max-rate 64kb workloads

### DIFF
--- a/workloads/max-rate-1-topic-10-partitions-10p-10c-256kb.yaml
+++ b/workloads/max-rate-1-topic-10-partitions-10p-10c-256kb.yaml
@@ -1,0 +1,34 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: max-rate-1-topic-10-partitions-10p-10c-256kb
+
+topics: 1
+partitionsPerTopic: 10
+
+messageSize: 262144
+#payloadFile: "payload/payload-1Kb.data"
+useRandomizedPayloads: true
+randomBytesRatio: 0.5
+randomizedPayloadPoolSize: 100
+
+subscriptionsPerTopic: 1
+consumerPerSubscription: 10
+producersPerTopic: 10
+
+# Discover max-sustainable rate
+producerRate: 10000000
+
+consumerBacklogSizeGB: 0
+testDurationMinutes: 5

--- a/workloads/max-rate-1-topic-100-partitions-100p-100c-256kb.yaml
+++ b/workloads/max-rate-1-topic-100-partitions-100p-100c-256kb.yaml
@@ -1,0 +1,34 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: max-rate-1-topic-100-partitions-100p-100c-256kb
+
+topics: 1
+partitionsPerTopic: 100
+
+messageSize: 262144
+#payloadFile: "payload/payload-1Kb.data"
+useRandomizedPayloads: true
+randomBytesRatio: 0.5
+randomizedPayloadPoolSize: 100
+
+subscriptionsPerTopic: 1
+consumerPerSubscription: 100
+producersPerTopic: 100
+
+# Discover max-sustainable rate
+producerRate: 10000000
+
+consumerBacklogSizeGB: 0
+testDurationMinutes: 5

--- a/workloads/max-rate-1-topic-20-partitions-20p-20c-256kb.yaml
+++ b/workloads/max-rate-1-topic-20-partitions-20p-20c-256kb.yaml
@@ -1,0 +1,34 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: max-rate-1-topic-20-partitions-20p-20c-256kb
+
+topics: 1
+partitionsPerTopic: 20
+
+messageSize: 262144
+#payloadFile: "payload/payload-1Kb.data"
+useRandomizedPayloads: true
+randomBytesRatio: 0.5
+randomizedPayloadPoolSize: 100
+
+subscriptionsPerTopic: 1
+consumerPerSubscription: 20
+producersPerTopic: 20
+
+# Discover max-sustainable rate
+producerRate: 10000000
+
+consumerBacklogSizeGB: 0
+testDurationMinutes: 5

--- a/workloads/max-rate-1-topic-30-partitions-30p-30c-256kb.yaml
+++ b/workloads/max-rate-1-topic-30-partitions-30p-30c-256kb.yaml
@@ -1,0 +1,34 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: max-rate-1-topic-30-partitions-30p-30c-256kb
+
+topics: 1
+partitionsPerTopic: 30
+
+messageSize: 262144
+#payloadFile: "payload/payload-1Kb.data"
+useRandomizedPayloads: true
+randomBytesRatio: 0.5
+randomizedPayloadPoolSize: 100
+
+subscriptionsPerTopic: 1
+consumerPerSubscription: 30
+producersPerTopic: 30
+
+# Discover max-sustainable rate
+producerRate: 10000000
+
+consumerBacklogSizeGB: 0
+testDurationMinutes: 5

--- a/workloads/max-rate-1-topic-30-partitions-30p-30c-64kb.yaml
+++ b/workloads/max-rate-1-topic-30-partitions-30p-30c-64kb.yaml
@@ -1,0 +1,33 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: max-rate-1-topic-30-partitions-30p-30c-64kb
+
+topics: 1
+partitionsPerTopic: 30
+messageSize: 65536
+#payloadFile: "payload/payload-1Kb.data"
+useRandomizedPayloads: true
+randomBytesRatio: 0.5
+randomizedPayloadPoolSize: 100
+
+subscriptionsPerTopic: 1
+consumerPerSubscription: 30
+producersPerTopic: 30
+
+# Discover max-sustainable rate
+producerRate: 10000000
+
+consumerBacklogSizeGB: 0
+testDurationMinutes: 5

--- a/workloads/max-rate-1-topic-40-partitions-40p-40c-256kb.yaml
+++ b/workloads/max-rate-1-topic-40-partitions-40p-40c-256kb.yaml
@@ -1,0 +1,34 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: max-rate-1-topic-40-partitions-40p-40c-256kb
+
+topics: 1
+partitionsPerTopic: 40
+
+messageSize: 262144
+#payloadFile: "payload/payload-1Kb.data"
+useRandomizedPayloads: true
+randomBytesRatio: 0.5
+randomizedPayloadPoolSize: 100
+
+subscriptionsPerTopic: 1
+consumerPerSubscription: 40
+producersPerTopic: 40
+
+# Discover max-sustainable rate
+producerRate: 10000000
+
+consumerBacklogSizeGB: 0
+testDurationMinutes: 5

--- a/workloads/max-rate-1-topic-50-partitions-50p-50c-256kb.yaml
+++ b/workloads/max-rate-1-topic-50-partitions-50p-50c-256kb.yaml
@@ -1,0 +1,34 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: max-rate-1-topic-50-partitions-50p-50c-256kb
+
+topics: 1
+partitionsPerTopic: 50
+
+messageSize: 262144
+#payloadFile: "payload/payload-1Kb.data"
+useRandomizedPayloads: true
+randomBytesRatio: 0.5
+randomizedPayloadPoolSize: 100
+
+subscriptionsPerTopic: 1
+consumerPerSubscription: 50
+producersPerTopic: 50
+
+# Discover max-sustainable rate
+producerRate: 10000000
+
+consumerBacklogSizeGB: 0
+testDurationMinutes: 5

--- a/workloads/max-rate-1-topic-50-partitions-50p-50c-64kb.yaml
+++ b/workloads/max-rate-1-topic-50-partitions-50p-50c-64kb.yaml
@@ -1,0 +1,33 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: max-rate-1-topic-50-partitions-50p-50c-64kb
+
+topics: 1
+partitionsPerTopic: 50
+messageSize: 65536
+#payloadFile: "payload/payload-1Kb.data"
+useRandomizedPayloads: true
+randomBytesRatio: 0.5
+randomizedPayloadPoolSize: 100
+
+subscriptionsPerTopic: 1
+consumerPerSubscription: 50
+producersPerTopic: 50
+
+# Discover max-sustainable rate
+producerRate: 10000000
+
+consumerBacklogSizeGB: 0
+testDurationMinutes: 5

--- a/workloads/max-rate-1-topic-60-partitions-60p-60c-256kb.yaml
+++ b/workloads/max-rate-1-topic-60-partitions-60p-60c-256kb.yaml
@@ -1,0 +1,34 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: max-rate-1-topic-60-partitions-60p-60c-256kb
+
+topics: 1
+partitionsPerTopic: 60
+
+messageSize: 262144
+#payloadFile: "payload/payload-1Kb.data"
+useRandomizedPayloads: true
+randomBytesRatio: 0.5
+randomizedPayloadPoolSize: 100
+
+subscriptionsPerTopic: 1
+consumerPerSubscription: 60
+producersPerTopic: 60
+
+# Discover max-sustainable rate
+producerRate: 10000000
+
+consumerBacklogSizeGB: 0
+testDurationMinutes: 5

--- a/workloads/max-rate-1-topic-70-partitions-70p-70c-256kb.yaml
+++ b/workloads/max-rate-1-topic-70-partitions-70p-70c-256kb.yaml
@@ -1,0 +1,34 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: max-rate-1-topic-70-partitions-70p-70c-256kb
+
+topics: 1
+partitionsPerTopic: 70
+
+messageSize: 262144
+#payloadFile: "payload/payload-1Kb.data"
+useRandomizedPayloads: true
+randomBytesRatio: 0.5
+randomizedPayloadPoolSize: 100
+
+subscriptionsPerTopic: 1
+consumerPerSubscription: 70
+producersPerTopic: 70
+
+# Discover max-sustainable rate
+producerRate: 10000000
+
+consumerBacklogSizeGB: 0
+testDurationMinutes: 5

--- a/workloads/max-rate-1-topic-70-partitions-70p-70c-64kb.yaml
+++ b/workloads/max-rate-1-topic-70-partitions-70p-70c-64kb.yaml
@@ -1,0 +1,33 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: max-rate-1-topic-70-partitions-70p-70c-64kb
+
+topics: 1
+partitionsPerTopic: 70
+messageSize: 65536
+#payloadFile: "payload/payload-1Kb.data"
+useRandomizedPayloads: true
+randomBytesRatio: 0.5
+randomizedPayloadPoolSize: 100
+
+subscriptionsPerTopic: 1
+consumerPerSubscription: 70
+producersPerTopic: 70
+
+# Discover max-sustainable rate
+producerRate: 10000000
+
+consumerBacklogSizeGB: 0
+testDurationMinutes: 5

--- a/workloads/max-rate-1-topic-80-partitions-80p-80c-256kb.yaml
+++ b/workloads/max-rate-1-topic-80-partitions-80p-80c-256kb.yaml
@@ -1,0 +1,34 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: max-rate-1-topic-80-partitions-80p-80c-256kb
+
+topics: 1
+partitionsPerTopic: 80
+
+messageSize: 262144
+#payloadFile: "payload/payload-1Kb.data"
+useRandomizedPayloads: true
+randomBytesRatio: 0.5
+randomizedPayloadPoolSize: 100
+
+subscriptionsPerTopic: 1
+consumerPerSubscription: 80
+producersPerTopic: 80
+
+# Discover max-sustainable rate
+producerRate: 10000000
+
+consumerBacklogSizeGB: 0
+testDurationMinutes: 5

--- a/workloads/max-rate-1-topic-90-partitions-90p-90c-256kb.yaml
+++ b/workloads/max-rate-1-topic-90-partitions-90p-90c-256kb.yaml
@@ -1,0 +1,34 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: max-rate-1-topic-90-partitions-90p-90c-256kb
+
+topics: 1
+partitionsPerTopic: 90
+
+messageSize: 262144
+#payloadFile: "payload/payload-1Kb.data"
+useRandomizedPayloads: true
+randomBytesRatio: 0.5
+randomizedPayloadPoolSize: 100
+
+subscriptionsPerTopic: 1
+consumerPerSubscription: 90
+producersPerTopic: 90
+
+# Discover max-sustainable rate
+producerRate: 10000000
+
+consumerBacklogSizeGB: 0
+testDurationMinutes: 5

--- a/workloads/max-rate-1-topic-90-partitions-90p-90c-64kb.yaml
+++ b/workloads/max-rate-1-topic-90-partitions-90p-90c-64kb.yaml
@@ -1,0 +1,33 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: max-rate-1-topic-90-partitions-90p-90c-64kb
+
+topics: 1
+partitionsPerTopic: 90
+messageSize: 65536
+#payloadFile: "payload/payload-1Kb.data"
+useRandomizedPayloads: true
+randomBytesRatio: 0.5
+randomizedPayloadPoolSize: 100
+
+subscriptionsPerTopic: 1
+consumerPerSubscription: 90
+producersPerTopic: 90
+
+# Discover max-sustainable rate
+producerRate: 10000000
+
+consumerBacklogSizeGB: 0
+testDurationMinutes: 5


### PR DESCRIPTION
- Added a new set of max-rate workloads 10p/c through 90p/c for 256kb message size
- Max-rate 64kb workloads only exist for 20/40/60/80, this also adds 30/50/70/90