### PR TITLE
Add maven exclusion for netty transitive dependency in artemis

### DIFF
--- a/benchmark-framework/pom.xml
+++ b/benchmark-framework/pom.xml
@@ -43,7 +43,7 @@
                 <exclusion>
                     <groupId>io.netty</groupId>
                     <artifactId>*</artifactId>
-                </exclusion>  
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/benchmark-framework/pom.xml
+++ b/benchmark-framework/pom.xml
@@ -39,6 +39,12 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>driver-artemis</artifactId>
             <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>  
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Fixes issue noted in https://github.com/openmessaging/benchmark/issues/363 , which was blocking me in production as well as locally

Currently the benchmark-framework module is unable to create the worker pool when given a list of workers due to a transitive dependency on netty-transport==4.1.77.Final which is pulled in from the artemis client, which conflicts with asynchttpclient's dependency on netty

This excludes all netty dependencies that the artemis library pulls in which resolves the issue. The artemis driver seems to be functional still without this transitive dependency. 

You can reproduce this issue locally by starting benchmark-worker and attempting to run any benchmark using those workers. Adding the exclusion and rebuilding allows the benchmark to work as intended.

This also seems to resolve an issue I was encountering where the benchmark will fail to terminate the java process once it completes. The bin/benchmark executable now terminates successfully upon completion. 