### PR TITLE
Bumped Jedis to v5.0.0 - fixed breaking changes from v3.7.0

### DIFF
--- a/driver-redis/pom.xml
+++ b/driver-redis/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>3.7.0</version>
+            <version>5.0.0</version>
         </dependency>
     </dependencies>
 

--- a/driver-redis/src/main/java/io/openmessaging/benchmark/driver/redis/RedisBenchmarkConsumer.java
+++ b/driver-redis/src/main/java/io/openmessaging/benchmark/driver/redis/RedisBenchmarkConsumer.java
@@ -27,9 +27,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
-import redis.clients.jedis.StreamEntry;
 import redis.clients.jedis.StreamEntryID;
 import redis.clients.jedis.params.XReadGroupParams;
+import redis.clients.jedis.resps.StreamEntry;
 
 public class RedisBenchmarkConsumer implements BenchmarkConsumer {
     private final JedisPool pool;

--- a/driver-redis/src/main/java/io/openmessaging/benchmark/driver/redis/RedisBenchmarkDriver.java
+++ b/driver-redis/src/main/java/io/openmessaging/benchmark/driver/redis/RedisBenchmarkDriver.java
@@ -28,11 +28,11 @@ import java.io.IOException;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import org.apache.bookkeeper.stats.StatsLogger;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
-import redis.clients.jedis.JedisPoolConfig;
 
 public class RedisBenchmarkDriver implements BenchmarkDriver {
     JedisPool jedisPool;
@@ -80,7 +80,7 @@ public class RedisBenchmarkDriver implements BenchmarkDriver {
     }
 
     private void setupJedisConn() {
-        JedisPoolConfig poolConfig = new JedisPoolConfig();
+        GenericObjectPoolConfig<Jedis> poolConfig = new GenericObjectPoolConfig<>();
         poolConfig.setMaxTotal(this.clientConfig.jedisPoolMaxTotal);
         poolConfig.setMaxIdle(this.clientConfig.jedisPoolMaxIdle);
         if (this.clientConfig.redisPass != null) {


### PR DESCRIPTION
This is a simple "homework" PR to update Jedis to the latest available version, while ensuring it keeps working as expected WRT the client breaking changes. 
Further PRs should come WRT further capabilities of redis that are not configurable now (cluster, resp3, pipelining, etc... ). 

To easily try out:
```
$ git clone https://github.com/redis-performance/openmessaging-benchmark --branch redis.jedis.5
$ cd openmessaging-benchmark
$ mvn install
$ bin/benchmark --drivers driver-redis/redis.yaml workloads/1-topic-1-partition-1kb.yaml
``` 