### PR TITLE
fix(driver-kafka): Fix the ineffective `KAFKA_JVM_PERFORMANCE_OPTS`

### DIFF
--- a/driver-kafka/deploy/hdd-deployment/templates/kafka.service
+++ b/driver-kafka/deploy/hdd-deployment/templates/kafka.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 ExecStart=/opt/kafka/bin/kafka-server-start.sh config/server.properties
 Environment='KAFKA_HEAP_OPTS=-Xms6g -Xmx6g -XX:MetaspaceSize=96m'
-Environment='KAFKA_JVM_PERFORMANCE_OPTS=-server -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:G1HeapRegionSize=16M -XX:MinMetaspaceFreeRatio=50 -XX:MaxMetaspaceFreeRatio=80 -Djava.awt.headless=true"
+Environment='KAFKA_JVM_PERFORMANCE_OPTS=-server -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:G1HeapRegionSize=16M -XX:MinMetaspaceFreeRatio=50 -XX:MaxMetaspaceFreeRatio=80 -Djava.awt.headless=true'
 WorkingDirectory=/opt/kafka
 RestartSec=1s
 Restart=on-failure

--- a/driver-kafka/deploy/ssd-deployment/templates/kafka.service
+++ b/driver-kafka/deploy/ssd-deployment/templates/kafka.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 ExecStart=/opt/kafka/bin/kafka-server-start.sh config/server.properties
 Environment='KAFKA_HEAP_OPTS=-Xms16g -Xmx16g -XX:MetaspaceSize=96m'
-Environment='KAFKA_JVM_PERFORMANCE_OPTS=-server -XX:+UnlockExperimentalVMOptions -XX:+UseZGC -XX:+ParallelRefProcEnabled -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=12 -XX:ConcGCThreads=12 -XX:+DisableExplicitGC -XX:-ResizePLAB -XX:MinMetaspaceFreeRatio=50 -XX:MaxMetaspaceFreeRatio=80 -Djava.awt.headless=true"
+Environment='KAFKA_JVM_PERFORMANCE_OPTS=-server -XX:+UnlockExperimentalVMOptions -XX:+UseZGC -XX:+ParallelRefProcEnabled -XX:+AggressiveOpts -XX:+DoEscapeAnalysis -XX:ParallelGCThreads=12 -XX:ConcGCThreads=12 -XX:+DisableExplicitGC -XX:-ResizePLAB -XX:MinMetaspaceFreeRatio=50 -XX:MaxMetaspaceFreeRatio=80 -Djava.awt.headless=true'
 WorkingDirectory=/opt/kafka
 RestartSec=1s
 Restart=on-failure


### PR DESCRIPTION
Mismatched single and double quotes caused KAFKA_JVM_PERFORMANCE_OPTS configuration to not take effect.

This was introduced in a commit 84a29dd928ffe879f5d8a2cc08f3d816867fd495 6 years ago.