### PR TITLE
Change topic ensure

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
@@ -146,7 +146,8 @@ public class WorkloadGenerator implements AutoCloseable {
         return result;
     }
 
-    private void ensureTopicsAreReady(ProducerWorkAssignment producerWorkAssignment) throws IOException {
+    private void ensureTopicsAreReady(ProducerWorkAssignment producerWorkAssignment)
+            throws IOException {
         log.info("Waiting for consumers to be ready");
         // This is work around the fact that there's no way to have a consumer ready in Kafka without
         // first publishing

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
@@ -76,8 +76,6 @@ public class WorkloadGenerator implements AutoCloseable {
         createConsumers(topics);
         createProducers(topics);
 
-        ensureTopicsAreReady();
-
         if (workload.producerRate > 0) {
             targetPublishRate = workload.producerRate;
         } else {
@@ -119,6 +117,7 @@ public class WorkloadGenerator implements AutoCloseable {
             producerWorkAssignment.payloadData.add(payloadReader.load(workload.payloadFile));
         }
 
+        ensureTopicsAreReady(producerWorkAssignment);
         worker.startLoad(producerWorkAssignment);
 
         if (workload.warmupDurationMinutes > 0) {
@@ -147,7 +146,7 @@ public class WorkloadGenerator implements AutoCloseable {
         return result;
     }
 
-    private void ensureTopicsAreReady() throws IOException {
+    private void ensureTopicsAreReady(ProducerWorkAssignment producerWorkAssignment) throws IOException {
         log.info("Waiting for consumers to be ready");
         // This is work around the fact that there's no way to have a consumer ready in Kafka without
         // first publishing
@@ -156,7 +155,7 @@ public class WorkloadGenerator implements AutoCloseable {
         int expectedMessages = workload.topics * workload.subscriptionsPerTopic;
 
         // In this case we just publish 1 message and then wait for consumers to receive the data
-        worker.probeProducers();
+        worker.probeProducers(producerWorkAssignment);
 
         long start = System.currentTimeMillis();
         long end = start + 60 * 1000;

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/DistributedWorkersEnsemble.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/DistributedWorkersEnsemble.java
@@ -136,12 +136,12 @@ public class DistributedWorkersEnsemble implements Worker {
     }
 
     @Override
-    public void probeProducers() throws IOException {
+    public void probeProducers(ProducerWorkAssignment producerWorkAssignment) throws IOException {
         producerWorkers.parallelStream()
                 .forEach(
                         w -> {
                             try {
-                                w.probeProducers();
+                                w.probeProducers(producerWorkAssignment);
                             } catch (IOException e) {
                                 throw new RuntimeException(e);
                             }

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/HttpWorkerClient.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/HttpWorkerClient.java
@@ -89,8 +89,8 @@ public class HttpWorkerClient implements Worker {
     }
 
     @Override
-    public void probeProducers() throws IOException {
-        sendPost(PROBE_PRODUCERS);
+    public void probeProducers(ProducerWorkAssignment producerWorkAssignment) throws IOException {
+        sendPost(PROBE_PRODUCERS, writer.writeValueAsBytes(producerWorkAssignment));
     }
 
     @Override

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/LocalWorker.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/LocalWorker.java
@@ -13,6 +13,8 @@
  */
 package io.openmessaging.benchmark.worker;
 
+import static java.util.stream.Collectors.toList;
+
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
@@ -37,11 +39,6 @@ import io.openmessaging.benchmark.worker.commands.CumulativeLatencies;
 import io.openmessaging.benchmark.worker.commands.PeriodStats;
 import io.openmessaging.benchmark.worker.commands.ProducerWorkAssignment;
 import io.openmessaging.benchmark.worker.commands.TopicsInfo;
-import org.apache.bookkeeper.stats.NullStatsLogger;
-import org.apache.bookkeeper.stats.StatsLogger;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -56,8 +53,10 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
-
-import static java.util.stream.Collectors.toList;
+import org.apache.bookkeeper.stats.NullStatsLogger;
+import org.apache.bookkeeper.stats.StatsLogger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class LocalWorker implements Worker, ConsumerCallback {
 
@@ -95,9 +94,9 @@ public class LocalWorker implements Worker, ConsumerCallback {
                     (BenchmarkDriver) Class.forName(driverConfiguration.driverClass).newInstance();
             benchmarkDriver.initialize(driverConfigFile, stats.getStatsLogger());
         } catch (InstantiationException
-                 | IllegalAccessException
-                 | ClassNotFoundException
-                 | InterruptedException e) {
+                | IllegalAccessException
+                | ClassNotFoundException
+                | InterruptedException e) {
             throw new RuntimeException(e);
         }
     }
@@ -194,10 +193,10 @@ public class LocalWorker implements Worker, ConsumerCallback {
         KeyDistributor keyDistributor = KeyDistributor.build(producerWorkAssignment.keyDistributorType);
         producers.forEach(
                 producer ->
-                        producer.sendAsync(
+                        producer
+                                .sendAsync(
                                         Optional.ofNullable(keyDistributor.next()),
-                                        producerWorkAssignment.payloadData.get(r.nextInt(payloadCount))
-                                )
+                                        producerWorkAssignment.payloadData.get(r.nextInt(payloadCount)))
                                 .thenRun(stats::recordMessageSent));
     }
 

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/Worker.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/Worker.java
@@ -34,7 +34,7 @@ public interface Worker extends AutoCloseable {
 
     void createConsumers(ConsumerAssignment consumerAssignment) throws IOException;
 
-    void probeProducers() throws IOException;
+    void probeProducers(ProducerWorkAssignment producerWorkAssignment) throws IOException;
 
     void startLoad(ProducerWorkAssignment producerWorkAssignment) throws IOException;
 

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/WorkerHandler.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/worker/WorkerHandler.java
@@ -90,7 +90,7 @@ public class WorkerHandler {
     }
 
     private void handleProbeProducers(Context ctx) throws Exception {
-        localWorker.probeProducers();
+        localWorker.probeProducers(mapper.readValue(ctx.body(), ProducerWorkAssignment.class));
     }
 
     private void handleCreateConsumers(Context ctx) throws Exception {

--- a/benchmark-framework/src/test/java/io/openmessaging/benchmark/utils/PaddingDecimalFormatTest.java
+++ b/benchmark-framework/src/test/java/io/openmessaging/benchmark/utils/PaddingDecimalFormatTest.java
@@ -17,13 +17,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 
+import java.text.DecimalFormat;
+
 class PaddingDecimalFormatTest {
 
     @Test
     void format() {
         PaddingDecimalFormat format = new PaddingDecimalFormat("0.0", 7);
-        assertThat(format.format(1L)).isEqualTo("    1.0");
-        assertThat(format.format(1000L)).isEqualTo(" 1000.0");
-        assertThat(format.format(10000000L)).isEqualTo("10000000.0");
+        DecimalFormat expectedFormat = new DecimalFormat("0.0");
+        assertThat(format.format(1L)).isEqualTo("    " + expectedFormat.format(1L));
+        assertThat(format.format(1000L)).isEqualTo(" " + expectedFormat.format(1000L));
+        assertThat(format.format(10000000L)).isEqualTo(expectedFormat.format(10000000L));
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <bookkeeper.version>4.14.4</bookkeeper.version>
         <checkstyle.version>10.3.3</checkstyle.version>
         <commons.lang3.version>3.12.0</commons.lang3.version>
-        <log4j.version>2.17.1</log4j.version>
+        <log4j.version>2.20.0</log4j.version>
         <lombok.version>1.18.24</lombok.version>
         <jackson.version>2.13.2</jackson.version>
         <jcommander.version>1.48</jcommander.version>


### PR DESCRIPTION
**Problem**: I am trying to use Openmessaging Benchmark for the performance testing of our in-house message broker. However, we have strict message schema validation, so probing the producers doesn't work for us, as it only sends an empty byte array.

**Solution**: Send the same messages used for testing.
