### PR TITLE
Enable optimized Netty direct bytebuffer reflection access

### DIFF
--- a/bin/benchmark
+++ b/bin/benchmark
@@ -27,4 +27,4 @@ fi
 JVM_MEM="${HEAP_OPTS} -XX:+UseG1GC"
 JVM_GC_LOG=" -XX:+PrintGCDetails -XX:+PrintGCApplicationStoppedTime  -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=64m  -Xloggc:/dev/shm/benchmark-client-gc_%p.log"
 
-java -server -cp $CLASSPATH $JVM_MEM io.openmessaging.benchmark.Benchmark $*
+java -server -cp $CLASSPATH $JVM_MEM io.openmessaging.benchmark.Benchmark "$@"

--- a/bin/benchmark-worker
+++ b/bin/benchmark-worker
@@ -26,5 +26,12 @@ fi
 
 JVM_MEM="${HEAP_OPTS} -XX:+UseG1GC"
 JVM_GC_LOG=" -XX:+PrintGCDetails -XX:+PrintGCApplicationStoppedTime  -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=5 -XX:GCLogFileSize=64m  -Xloggc:/dev/shm/benchmark-client-gc_%p.log"
-
-exec java -server -cp $CLASSPATH $JVM_MEM io.openmessaging.benchmark.worker.BenchmarkWorker $*
+# Required by Netty for optimized direct byte buffer access
+JVM_OPTS="$JVM_OPTS -Dio.netty.tryReflectionSetAccessible=true"
+JVM_OPTS="$JVM_OPTS --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED"
+# Set io.netty.tryReflectionSetAccessible in Pulsar's shaded client
+JVM_OPTS="$JVM_OPTS -Dorg.apache.pulsar.shade.io.netty.tryReflectionSetAccessible=true"
+# Required by Pulsar client optimized checksum calculation on other than Linux x86_64 platforms
+# reflection access to java.util.zip.CRC32C
+JVM_OPTS="$JVM_OPTS --add-opens java.base/java.util.zip=ALL-UNNAMED"
+exec java -server -cp $CLASSPATH $JVM_MEM $JVM_OPTS io.openmessaging.benchmark.worker.BenchmarkWorker "$@"

--- a/pom.xml
+++ b/pom.xml
@@ -352,7 +352,13 @@
                 <version>${maven.surefire.plugin.version}</version>
                 <configuration>
                     <!-- Required by system-lambda test dependency -->
-                    <argLine>--add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+                    <!-- Required by Netty for optimized direct byte buffer access -->
+                    <!-- Required by Pulsar client for optimized direct byte buffer access and optimized checksum calculation -->
+                    <argLine>--add-opens java.base/java.util=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED
+                        -Dio.netty.tryReflectionSetAccessible=true
+                        --add-opens java.base/java.nio=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
+                        -Dorg.apache.pulsar.shade.io.netty.tryReflectionSetAccessible=true
+                        --add-opens java.base/java.util.zip=ALL-UNNAMED</argLine>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
OMB benchmark worker should enable Netty's optimized direct bytebuffer support. 
This PR sets the required JVM options for the benchmark-worker.