### PR TITLE
Improve Pulsar AWS deployment (terraform + ansible)

### DIFF
--- a/driver-pulsar/README.md
+++ b/driver-pulsar/README.md
@@ -3,13 +3,16 @@
 For instructions on running the OpenMessaging benchmarks for Pulsar, see the [official documentation](http://openmessaging.cloud/docs/benchmarks/pulsar/).
 
 ## Supplement to the official documentation
-
-Before you run `ansible-playbook` with `terraform-inventory`, you must set the environment variable `TF_STATE`. i.e. the completed command should be:
+For Ansible to have access to the inventory defined in the Terraform configuration, the Terraform Collection for Ansible is required.
+Install it with the following command ([source](https://mdawar.dev/blog/ansible-terraform-inventory)):
+```bash
+ansible-galaxy collection install cloud.terraform
+```
 
 ```bash
-TF_STATE=. ansible-playbook \
+ansible-playbook \
   --user ec2-user \
-  --inventory `which terraform-inventory` \
+  --inventory terraform.yaml \
   deploy.yaml
 ```
 
@@ -20,17 +23,9 @@ The Ansible deployment script supports flexible configuration with a variable fi
 ```bash
 TF_STATE=. ansible-playbook \
   --user ec2-user \
-  --inventory `which terraform-inventory` \
+  --inventory terraform.yaml \
   -e @extra_vars.yaml \
   deploy.yaml
-```
-
-For example, if you changed the AWS instance type, the two SSD device paths might not be `/dev/nvme1n1` and `/dev/nvme2n1`. In this case, you can configure them like
-
-```yaml
-disk_dev:
-  - /path/to/disk1
-  - /path/to/disk2
 ```
 
 See more explanations in [the example variable file](./deploy/ssd/extra_vars.yaml).
@@ -56,9 +51,9 @@ It will download KoP and MoP from the given URLs. Then, the configuration templa
 You can change the configuration files and then restart the cluster by executing the following command.
 
 ```bash
-TF_STATE=. ansible-playbook \
+ansible-playbook \
   --user ec2-user \
-  --inventory `which terraform-inventory` \
+  --inventory terraform.yaml \
   -e @extra_vars.yaml \
   restart-brokers.yaml
 ```

--- a/driver-pulsar/README.md
+++ b/driver-pulsar/README.md
@@ -7,6 +7,7 @@ For Ansible to have access to the inventory defined in the Terraform configurati
 Install it with the following command ([source](https://mdawar.dev/blog/ansible-terraform-inventory)):
 ```bash
 ansible-galaxy collection install cloud.terraform
+ansible-galaxy role install geerlingguy.docker
 ```
 
 ```bash

--- a/driver-pulsar/deploy/ssd/deploy.yaml
+++ b/driver-pulsar/deploy/ssd/deploy.yaml
@@ -26,10 +26,9 @@
         pulsar_version: "{{ pulsar_version | default('2.11.0') }}"
         node_exporter_version: "{{ node_exporter_version | default('1.2.2') }}"
         prometheus_version: "{{ prometheus_version | default('2.31.1') }}"
-        disk_dev: "{{ disk_dev | default(['/dev/nvme1n1', '/dev/nvme2n1']) }}"
     - set_fact:
         pulsar_binary:
-          src: "https://downloads.apache.org/pulsar/pulsar-{{ pulsar_version }}/apache-pulsar-{{ pulsar_version }}-bin.tar.gz"
+          src: "https://archive.apache.org/dist/pulsar/pulsar-{{ pulsar_version }}/apache-pulsar-{{ pulsar_version }}-bin.tar.gz"
           remote: yes
       when: pulsar_binary is not defined
     - set_fact:
@@ -48,13 +47,27 @@
   connection: ssh
   become: true
   tasks:
+    - name: Initialize empty list for devices
+      set_fact:
+        storage_devices: []
+      no_log: true
+
+    - name: Get NVMe devices
+      set_fact:
+        storage_devices: "{{ storage_devices + ['/dev/' ~ item.key ] }}"
+      with_dict: "{{ ansible_devices }}"
+      when: "item.value.host.startswith('Non-Volatile memory controller:') and not item.value.partitions"
+
+    - name: Show device names
+      debug: var=storage_devices
+
     - name: Format disks
       filesystem:
         fstype: xfs
         dev: '{{ item }}'
       with_items:
-        - "{{ disk_dev[0] }}"
-        - "{{ disk_dev[1] }}"
+        - "{{ storage_devices[0] }}"
+        - "{{ storage_devices[1] }}"
     - name: Mount disks
       mount:
         path: "{{ item.path }}"
@@ -63,21 +76,35 @@
         opts: defaults,noatime,nodiscard
         state: mounted
       with_items:
-        - { path: "/mnt/zookeeper/logs", src: "{{ disk_dev[0] }}" }
-        - { path: "/mnt/zookeeper/data", src: "{{ disk_dev[1] }}" }
+        - { path: "/mnt/zookeeper/logs", src: "{{ storage_devices[0] }}" }
+        - { path: "/mnt/zookeeper/data", src: "{{ storage_devices[1] }}" }
 
 - name: Format and mount disks for Pulsar/BookKeeper hosts
   hosts: pulsar
   connection: ssh
   become: true
   tasks:
+    - name: Initialize empty list for devices
+      set_fact:
+        storage_devices: []
+      no_log: true
+
+    - name: Get NVMe devices
+      set_fact:
+        storage_devices: "{{ storage_devices + ['/dev/' ~ item.key ] }}"
+      with_dict: "{{ ansible_devices }}"
+      when: "item.value.host.startswith('Non-Volatile memory controller:') and not item.value.partitions"
+
+    - name: Show device names
+      debug: var=storage_devices
+
     - name: Format disks
       filesystem:
          fstype: xfs
          dev: '{{ item }}'
       with_items:
-        - "{{ disk_dev[0] }}"
-        - "{{ disk_dev[1] }}"
+        - "{{ storage_devices[0] }}"
+        - "{{ storage_devices[1] }}"
     - name: Mount disks
       mount:
         path: "{{ item.path }}"
@@ -86,8 +113,8 @@
         opts: defaults,noatime,nodiscard
         state: mounted
       with_items:
-        - { path: "/mnt/journal", src: "{{ disk_dev[0] }}" }
-        - { path: "/mnt/storage", src: "{{ disk_dev[1] }}" }
+        - { path: "/mnt/journal", src: "{{ storage_devices[0] }}" }
+        - { path: "/mnt/storage", src: "{{ storage_devices[1] }}" }
 
 - name: Install Node exporter on Brokers to collect system metrics
   hosts: pulsar

--- a/driver-pulsar/deploy/ssd/deploy.yaml
+++ b/driver-pulsar/deploy/ssd/deploy.yaml
@@ -383,12 +383,16 @@
       template:
         src: "templates/client.conf"
         dest: "/opt/pulsar/conf/client.conf"
-    - file: path=/opt/benchmark state=absent
     - name: Copy benchmark code
       unarchive:
         src: ../../../package/target/openmessaging-benchmark-0.0.1-SNAPSHOT-bin.tar.gz
         dest: /opt
-    - shell: mv /opt/openmessaging-benchmark-0.0.1-SNAPSHOT /opt/benchmark
+        creates: /opt/benchmark
+
+    - name: Rename benchmark directory
+      ansible.builtin.shell:
+        cmd: mv /opt/openmessaging-benchmark-0.0.1-SNAPSHOT /opt/benchmark
+        creates: /opt/benchmark
 
     - template:
         src: "templates/workers.yaml"

--- a/driver-pulsar/deploy/ssd/deploy.yaml
+++ b/driver-pulsar/deploy/ssd/deploy.yaml
@@ -56,7 +56,7 @@
       set_fact:
         storage_devices: "{{ storage_devices + ['/dev/' ~ item.key ] }}"
       with_dict: "{{ ansible_devices }}"
-      when: "item.value.host.startswith('Non-Volatile memory controller:') and not item.value.partitions"
+      when: "item.key.startswith('nvme') and not item.value.partitions"
 
     - name: Show device names
       debug: var=storage_devices
@@ -93,7 +93,7 @@
       set_fact:
         storage_devices: "{{ storage_devices + ['/dev/' ~ item.key ] }}"
       with_dict: "{{ ansible_devices }}"
-      when: "item.value.host.startswith('Non-Volatile memory controller:') and not item.value.partitions"
+      when: "item.key.startswith('nvme') and not item.value.partitions"
 
     - name: Show device names
       debug: var=storage_devices
@@ -179,19 +179,39 @@
   connection: ssh
   become: true
   tasks:
+    - name: Install Tuned packages
+      ansible.builtin.package:
+        state: latest
+        update_cache: true
+        name:
+          - tuned
+    - name: Enable Tuned
+      service: name=tuned state=started enabled=yes
     - name: Set performance profile
       command: tuned-adm profile latency-performance
-    - name: Install RPM packages
-      yum:
+    - name: Install packages
+      ansible.builtin.package:
         state: latest
-        pkg:
+        name:
           - wget
-          - java-17-openjdk
-          - java-17-openjdk-devel
           - sysstat
           - vim
           - chrony
-      when: ansible_facts['distribution'] == 'RedHat'
+    - name: Install java on RedHat/CentOS
+      ansible.builtin.package:
+        state: latest
+        name:
+          - java-17-openjdk
+          - java-17-openjdk-devel
+      when:
+        - ansible_facts['distribution'] == 'RedHat' or ansible_facts['distribution'] == 'CentOS'
+    - name: Install java on Debain/Ubuntu
+      ansible.builtin.package:
+        state: latest
+        name:
+          - openjdk-17-jdk
+      when:
+        - ansible_facts['distribution'] == 'Debian' or ansible_facts['distribution'] == 'Ubuntu'
     - file: path=/opt/pulsar state=absent
     - file: path=/opt/pulsar state=directory
     - name: Download Pulsar binary package
@@ -467,27 +487,9 @@
   connection: ssh
   become: true
   tasks:
-    - name: Add Extras Repo
-      shell: yum-config-manager --enable rhui-REGION-rhel-server-extras
-      when:
-        - ansible_facts['distribution'] == 'RedHat'
-        - ansible_facts['distribution_major_version'] | int <= 7
-    - name: Docker repo
-      yum_repository:
-        name: docker
-        description: repo for docker
-        baseurl: "https://download.docker.com/linux/centos/{{ ansible_facts['distribution_major_version'] }}/x86_64/stable/"
-        gpgcheck: no
-      when: ansible_facts['distribution'] == 'RedHat'
-    - name: Installing docker
-      yum:
-        state: latest
-        pkg: ['docker-ce']
-    - name: Start docker
-      service:
-        name: docker
-        state: started
-        enabled: yes
+    - name: Install docker
+      include_role:
+        name: geerlingguy.docker
     - file: path=/opt/prometheus state=absent
     - file: path=/opt/prometheus state=directory
     - name: Download Prometheus Binary Package

--- a/driver-pulsar/deploy/ssd/provision-pulsar-aws.tf
+++ b/driver-pulsar/deploy/ssd/provision-pulsar-aws.tf
@@ -37,12 +37,18 @@ variable "key_name" {
 variable "region" {}
 variable "az" {}
 variable "ami" {}
+variable "user" {}
 variable "spot" {}
 variable "instance_types" {}
 variable "num_instances" {}
 
 provider "aws" {
   region = var.region
+  default_tags {
+   tags = {
+      Project = "pulsar-benchmark"
+   }
+  }
 }
 
 # Create a VPC to launch our instances into
@@ -139,7 +145,7 @@ resource "aws_instance" "zookeeper" {
      content {
          market_type = "spot"
          spot_options {
-           max_price = 0.5
+           max_price = 3.0
          }
        }
    }
@@ -162,7 +168,7 @@ resource "aws_instance" "pulsar" {
      content {
          market_type = "spot"
          spot_options {
-           max_price = 0.7
+           max_price = 3.0
          }
      }
   }
@@ -185,7 +191,7 @@ resource "aws_instance" "client" {
      content {
          market_type = "spot"
          spot_options {
-           max_price = 0.9
+           max_price = 3.0
          }
      }
   }
@@ -226,7 +232,7 @@ resource "ansible_host" "zookeeper" {
 
   variables = {
     # Connection vars.
-    ansible_user = "ec2-user" # Default user depends on the OS.
+    ansible_user = var.user # Default user depends on the OS.
     ansible_host = aws_instance.zookeeper[count.index].public_ip
 
     # Custom vars that we might use in roles/tasks.
@@ -239,7 +245,7 @@ resource "ansible_host" "pulsar" {
 
   variables = {
     # Connection vars.
-    ansible_user = "ec2-user" # Default user depends on the OS.
+    ansible_user = var.user # Default user depends on the OS.
     ansible_host = aws_instance.pulsar[count.index].public_ip
 
     # Custom vars that we might use in roles/tasks.
@@ -252,7 +258,7 @@ resource "ansible_host" "client" {
 
   variables = {
     # Connection vars.
-    ansible_user = "ec2-user" # Default user depends on the OS.
+    ansible_user = var.user # Default user depends on the OS.
     ansible_host = aws_instance.client[count.index].public_ip
 
     # Custom vars that we might use in roles/tasks.
@@ -265,7 +271,7 @@ resource "ansible_host" "prometheus" {
 
   variables = {
     # Connection vars.
-    ansible_user = "ec2-user" # Default user depends on the OS.
+    ansible_user = var.user # Default user depends on the OS.
     ansible_host = aws_instance.prometheus[count.index].public_ip
 
     # Custom vars that we might use in roles/tasks.

--- a/driver-pulsar/deploy/ssd/terraform.tfvars
+++ b/driver-pulsar/deploy/ssd/terraform.tfvars
@@ -1,7 +1,8 @@
 public_key_path = "~/.ssh/pulsar_aws.pub"
-region          = "us-west-2"
-az              = "us-west-2a"
-ami             = "ami-08970fb2e5767e3b8" // RHEL-8
+region          = "us-east-2"
+az              = "us-east-2a"
+ami             = "ami-012e6364f6bd17628"
+user            = "ubuntu"
 spot            = false
 
 instance_types = {

--- a/driver-pulsar/deploy/ssd/terraform.tfvars
+++ b/driver-pulsar/deploy/ssd/terraform.tfvars
@@ -2,7 +2,7 @@ public_key_path = "~/.ssh/pulsar_aws.pub"
 region          = "us-west-2"
 az              = "us-west-2a"
 ami             = "ami-08970fb2e5767e3b8" // RHEL-8
-spot            = true
+spot            = false
 
 instance_types = {
   "pulsar"     = "i3en.6xlarge"

--- a/driver-pulsar/deploy/ssd/terraform.tfvars
+++ b/driver-pulsar/deploy/ssd/terraform.tfvars
@@ -2,6 +2,7 @@ public_key_path = "~/.ssh/pulsar_aws.pub"
 region          = "us-west-2"
 az              = "us-west-2a"
 ami             = "ami-08970fb2e5767e3b8" // RHEL-8
+spot            = true
 
 instance_types = {
   "pulsar"     = "i3en.6xlarge"

--- a/driver-pulsar/deploy/ssd/terraform.yaml
+++ b/driver-pulsar/deploy/ssd/terraform.yaml
@@ -1,0 +1,4 @@
+plugin: cloud.terraform.terraform_provider
+project_path: .
+# Terraform binary (available in the $PATH) or full path to the binary.
+binary_path: terraform


### PR DESCRIPTION
This PR enhances the deployment of Pulsar on AWS using Terraform and Ansible, incorporating several improvements and optimizations:

1) Prevent redundant benchmark code uploads: Optimized benchmark code deployment by splitting and using creates to avoid unnecessary uploads.

2) Dynamic discovery of storage devices: Replaced hardcoded disk labels with Ansible-based discovery, ensuring reliable deployment across AWS instances where device labels may change post-reboot.

 3) Replace terraform-inventory with Ansible Provider and support for spot instances
        Upgraded to Ansible Provider and Terraform Ansible-Collection, retiring outdated terraform-inventory plugin.
        Introduced support for deploying instances as AWS spot instances via a new configurable variable (default = False).

These changes collectively enhance deployment reliability and introduce flexibility in instance provisioning for Pulsar and Bookkeeper deployments on AWS.