### PR TITLE
Updated Docker build files so they are working again

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# OpenMessaging Benchmark Framework
+# Fork of the OpenMessaging Benchmark Framework that uses sapmachine 17 docker image
+
+This fork is used to update the outdated offical docker hub image openmessaging/openmessaging-benchmark with sapmachine:17.
+Find more in [./docker/README.md](./docker/README.md).
 
 [![Build](https://github.com/openmessaging/benchmark/actions/workflows/pr-build-and-test.yml/badge.svg)](https://github.com/openmessaging/benchmark/actions/workflows/pr-build-and-test.yml)
 [![License](https://img.shields.io/badge/license-Apache%202-4EB1BA.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
@@ -27,7 +30,7 @@ This repository houses user-friendly, cloud-ready benchmarking suites for the fo
 
 Requirements:
 
-* JDK 8
+* JDK 17
 * Maven 3.8.6+
 
 Common build actions:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@
 # limitations under the License.
 #
 
-FROM openjdk:8-jdk
+FROM sapmachine:17
 
 ARG BENCHMARK_TARBALL
 

--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -13,13 +13,13 @@
 #
 
 # Build the Project
-FROM maven:latest as build
+FROM maven:3.9.9-sapmachine-17 as build
 COPY . /benchmark
 WORKDIR /benchmark
 RUN mvn install
 
 # Create the benchmark image
-FROM openjdk:8-jdk
+FROM sapmachine:17
 COPY --from=build /benchmark/package/target/openmessaging-benchmark-*-SNAPSHOT-bin.tar.gz /
 RUN mkdir /benchmark && tar -xzf openmessaging-benchmark-*-SNAPSHOT-bin.tar.gz -C /benchmark --strip=1
 RUN rm /openmessaging-benchmark-*-SNAPSHOT-bin.tar.gz

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,10 +1,17 @@
 # OpenMessaging Benchmark Framework Docker
 
+## Precondition
+
+You need to install [sapmachine 17](https://sapmachine.io/)
+and set the JAVA_HOME environment variable to its installation directory.
+
+## Building the image
+
 You can use either of the Dockerfiles - `./docker/Dockerfile` or `./docker/Dockerfile.build` based on your needs.
 
 ### `Dockerfile`
 
-Uses `openjdk-8` and takes `BENCHMARK_TARBALL` as an argument.  
+Uses `sapmachine:17` and takes `BENCHMARK_TARBALL` as an argument.
 While using this Dockerfile, you will need to build the project locally **first**.
 
 ```
@@ -15,8 +22,8 @@ While using this Dockerfile, you will need to build the project locally **first*
 
 ### `Dockerfile.build`
 
-Uses the latest version of `maven` in order to build the project, and then use `openjdk-8` as runtime.  
-This Dockerfile has no dependency (you do not need Mavent to be installed locally).
+Uses the latest version of `maven` in order to build the project, and then use `sapmachine:17` as runtime.
+This Dockerfile has no dependency (you do not need Maven to be installed locally).
 
 ```
 #> docker build . -f docker/Dockerfile.build


### PR DESCRIPTION
We are using the benchmark tests for testing K8s Kafka clusters within our SAP landscapes. In the [docker](./docker) folder there where build files, that where not working for us. Therefore, I've adapted them to our needs but I think the changes are company independent. So **sapmachine** is an open source Java distribution and a good replacement for the outdated **openjdk**.

Please consider merging this PR.