### PR TITLE
feat: add consumeDelaySeconds for time-based consumer delay

### DIFF
--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/Workload.java
@@ -83,4 +83,12 @@ public class Workload {
     public int testDurationMinutes;
 
     public int warmupDurationMinutes = 1;
+
+    /**
+     * If > 0, after warmup the consumers are paused for exactly this many seconds before being
+     * automatically resumed and the measurement window starts. Use this when you want time-based
+     * backlog accumulation (e.g. to ensure data is offloaded to tiered storage before consumers
+     * start draining), as an alternative to size-based {@link #consumerBacklogSizeGB}.
+     */
+    public int consumeDelaySeconds = 0;
 }

--- a/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
+++ b/benchmark-framework/src/main/java/io/openmessaging/benchmark/WorkloadGenerator.java
@@ -164,6 +164,7 @@ public class WorkloadGenerator implements AutoCloseable {
         }
 
         worker.resetStats();
+        applyConsumeDelayIfConfigured();
         log.info("----- Starting benchmark traffic ({}m)------", workload.testDurationMinutes);
 
         TestResult result = printAndCollectStats(workload.testDurationMinutes, TimeUnit.MINUTES);
@@ -251,6 +252,23 @@ public class WorkloadGenerator implements AutoCloseable {
     public void close() throws Exception {
         worker.stopAll();
         executor.shutdownNow();
+    }
+
+    private void applyConsumeDelayIfConfigured() throws IOException {
+        if (workload.consumeDelaySeconds <= 0) {
+            return;
+        }
+        worker.pauseConsumers();
+        log.info("----- Delaying consumption for {}s before measurement window -----",
+                workload.consumeDelaySeconds);
+        try {
+            Thread.sleep(workload.consumeDelaySeconds * 1000L);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+        worker.resumeConsumers();
+        log.info("----- Consumers resumed after {}s delay -----", workload.consumeDelaySeconds);
     }
 
     private void createConsumers(List<String> topics) throws IOException {


### PR DESCRIPTION
## Summary
- Adds a `consumeDelaySeconds` field to `Workload`. When > 0, the framework automatically pauses all consumers immediately after warmup, sleeps for the configured number of seconds, then resumes consumers before the measurement window begins.
- Enables tiered-storage style scenarios where backlog must accumulate and (for Pulsar) be offloaded before consumers start draining, without requiring an external coordinator.

## Motivation
`consumerBacklogSizeGB` builds backlog by *size*, but for tiered-storage benchmarks we need a *time-based* gap so the broker has a deterministic window to flush ledgers and offload them. A simple time-based delay that the framework owns end-to-end is the cleanest expression of that.

## Behavior
- Default value `0` ⇒ no behavior change for existing workloads.
- When `> 0`, after `warmupDurationMinutes` and `worker.resetStats()`, `worker.pauseConsumers()` is called, the thread sleeps for `consumeDelaySeconds`, then `worker.resumeConsumers()` is called before the measurement loop starts.
- Targets a different scenario from `consumerBacklogSizeGB`; if both are set the existing backlog logic still runs and the consume-delay window happens before the measurement loop.

## Test plan
- [ ] `mvn -pl benchmark-framework -am clean compile` passes (verified locally).
- [ ] Existing workloads without `consumeDelaySeconds` are unaffected.
- [ ] A workload with `consumeDelaySeconds: 60` pauses consumers for 60s after warmup, then resumes.